### PR TITLE
Bootstrap API server skeleton

### DIFF
--- a/internal/handlers/downloads.go
+++ b/internal/handlers/downloads.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+type Download struct {
+	l *log.Logger
+}
+
+func NewDownload(l *log.Logger) *Download {
+	return &Download{l}
+}
+
+func (d *Download) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	d.l.Println("Downloading files...")
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "oops", http.StatusBadRequest)
+		return
+	}
+	d.l.Printf("Data %s\n", data)
+
+	fmt.Fprintf(w, "%s", data)
+}


### PR DESCRIPTION
Initial setup for the Torrus API service. This change introduces:

Basic HTTP server on port 9090 with graceful shutdown

/downloads endpoint with placeholder handler (currently just logs and echoes request body)

Logging with standard Go log package

Basic signal handling for SIGINT and SIGKILL