### PR TITLE
feat: Increase signal channel to buffered size of 1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ func main() {
 		}
 	}()
 
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt)
   signal.Notify(sigChan, os.Kill)
 


### PR DESCRIPTION
Unbuffered channels can block the signal.Notify sender if multiple signals are sent before the receiver reads them. A buffered channel of size 1 ensures at least one signal is captured without blocking.