### PR TITLE
feat(downloads): Add GET /downloads with in-memory store

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 
 	l := log.New(os.Stdout, "torrus-api ", log.LstdFlags)
-	downloadHandler := handlers.NewDownload(l)
+	downloadHandler := handlers.NewDownloads(l)
 
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/downloads", downloadHandler)

--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -1,0 +1,43 @@
+package data
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type Download struct {
+	ID         int    `json:"id"`
+	Source     string `json:"source"`
+	TargetPath string `json:"targetPath"`
+	Status     string `json:"status"`
+	CreatedAt  string `json:"-"`
+}
+
+type Downloads []*Download
+
+func (d *Downloads) ToJSON(w io.Writer) error {
+	e := json.NewEncoder(w)
+	return e.Encode(d)
+}
+
+func GetDownloads() Downloads {
+	return downloadList
+}
+
+var downloadList = []*Download{
+	&Download{
+		ID:         1,
+		Source:     "magnet:?xt=urn:btih:a216611be5b8d8c6306748d132774aa514977ee8&dn=Chappelle%27s+Show+%5B2003%5D&tr=http%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fzer0day.to%3A1337%2Fannounce&tr=http%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce&tr=http%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=http%3A%2F%2F5.79.83.193%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=http%3A%2F%2Fbt.henbt.com%3A2710%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce",
+		TargetPath: "/tv/",
+		Status:     "in progress",
+		CreatedAt:  time.Now().UTC().String(),
+	},
+	&Download{
+		ID:         2,
+		Source:     "magnet:?xt=urn:btih:1300da4907fcec1470bb3cd31563bb401cd33c14&dn=Superman+%282025%29+En+2160p+UHD+X265+HEVC+10+bit+Dolby+Digital+Plus%5BMulti-Sub%5D.mkv&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fzephir.monocul.us%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.pomf.se%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=http%3A%2F%2Fipv4.rer.lol%3A2710%2Fannounce&tr=http%3A%2F%2Fhome.yxgz.club%3A6969%2Fannounce&tr=http%3A%2F%2Fbt.okmp3.ru%3A2710%2Fannounce&tr=http%3A%2F%2Fbt1.xxxxbt.cc%3A6969%2Fannounce&tr=http%3A%2F%2F207.241.226.111%3A6969%2Fannounce",
+		TargetPath: "/movies/",
+		Status:     "in progress",
+		CreatedAt:  time.Now().UTC().String(),
+	},
+}

--- a/internal/handlers/downloads.go
+++ b/internal/handlers/downloads.go
@@ -1,28 +1,32 @@
 package handlers
 
 import (
-	"fmt"
-	"io"
 	"log"
 	"net/http"
+
+	"github.com/tinoosan/torrus/internal/data"
 )
 
-type Download struct {
+type Downloads struct {
 	l *log.Logger
 }
 
-func NewDownload(l *log.Logger) *Download {
-	return &Download{l}
+func NewDownloads(l *log.Logger) *Downloads {
+	return &Downloads{l}
 }
 
-func (d *Download) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	d.l.Println("Downloading files...")
-	data, err := io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "oops", http.StatusBadRequest)
+func (d *Downloads) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	 if r.Method == http.MethodGet{
+		d.getDownloads(w, r)
 		return
 	}
-	d.l.Printf("Data %s\n", data)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
 
-	fmt.Fprintf(w, "%s", data)
+func (d *Downloads) getDownloads(w http.ResponseWriter, r *http.Request) {
+	dl := data.GetDownloads()
+	err := dl.ToJSON(w)
+	if err != nil {
+		http.Error(w, "Unable to marshal json", http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
## Summary
Adds a temporary in-memory store of downloads and exposes a GET /downloads endpoint to return all current entries.

## Why
This sets up the read path for downloads before implementing POST and actual download initiation.

## Notes
- Data is hardcoded for now (2 sample downloads)
- Will be replaced with persistent or runtime store in later PR
