### PR TITLE
feat: Add POST /downloads to create in-memory download entries

### DIFF
--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Download struct {
-	ID            string         `json:"id"`
+	ID            int            `json:"id"`
 	GID           string         `json:"-"`
 	Source        string         `json:"source"`
 	TargetPath    string         `json:"targetPath"`
@@ -33,13 +33,28 @@ func (d *Downloads) ToJSON(w io.Writer) error {
 	return e.Encode(d)
 }
 
+func (d *Download) FromJSON(r io.Reader) error {
+	e := json.NewDecoder(r)
+	return e.Decode(d)
+}
+
 func GetDownloads() Downloads {
 	return downloadList
 }
 
+func AddDownload(d *Download) {
+	d.ID = getNextID()
+	d.Status = StatusQueued
+}
+
+func getNextID() int {
+	dl := downloadList[len(downloadList)-1]
+	return dl.ID + 1
+}
+
 var downloadList = []*Download{
 	&Download{
-		ID:         "1",
+		ID:         1,
 		GID:        "1",
 		Source:     "magnet:?xt=urn:btih:a216611be5b8d8c6306748d132774aa514977ee8&dn=Chappelle%27s+Show+%5B2003%5D&tr=http%3A%2F%2Ftracker.openbittorrent.com%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fzer0day.to%3A1337%2Fannounce&tr=http%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce&tr=http%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=http%3A%2F%2F5.79.83.193%3A2710%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=http%3A%2F%2Fbt.henbt.com%3A2710%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce",
 		TargetPath: "/tv/",
@@ -47,7 +62,7 @@ var downloadList = []*Download{
 		CreatedAt:  time.Now(),
 	},
 	&Download{
-		ID:         "2",
+		ID:         2,
 		GID:        "2",
 		Source:     "magnet:?xt=urn:btih:1300da4907fcec1470bb3cd31563bb401cd33c14&dn=Superman+%282025%29+En+2160p+UHD+X265+HEVC+10+bit+Dolby+Digital+Plus%5BMulti-Sub%5D.mkv&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fzephir.monocul.us%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.pomf.se%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=http%3A%2F%2Fipv4.rer.lol%3A2710%2Fannounce&tr=http%3A%2F%2Fhome.yxgz.club%3A6969%2Fannounce&tr=http%3A%2F%2Fbt.okmp3.ru%3A2710%2Fannounce&tr=http%3A%2F%2Fbt1.xxxxbt.cc%3A6969%2Fannounce&tr=http%3A%2F%2F207.241.226.111%3A6969%2Fannounce",
 		TargetPath: "/movies/",

--- a/internal/handlers/downloads.go
+++ b/internal/handlers/downloads.go
@@ -16,17 +16,36 @@ func NewDownloads(l *log.Logger) *Downloads {
 }
 
 func (d *Downloads) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	 if r.Method == http.MethodGet{
+	 if r.Method == http.MethodGet {
 		d.getDownloads(w, r)
 		return
 	}
+	 if r.Method == http.MethodPost {
+    d.addDownload(w, r)
+		return
+	}
+
 	w.WriteHeader(http.StatusMethodNotAllowed)
 }
 
 func (d *Downloads) getDownloads(w http.ResponseWriter, r *http.Request) {
+	d.l.Println("Handle GET Download")
 	dl := data.GetDownloads()
 	err := dl.ToJSON(w)
 	if err != nil {
 		http.Error(w, "Unable to marshal json", http.StatusInternalServerError)
 	}
+}
+
+func (d *Downloads) addDownload(w http.ResponseWriter, r *http.Request) {
+	d.l.Println("Handle POST Download")
+
+	dl := &data.Download{}
+	err := dl.FromJSON(r.Body)
+	if err != nil {
+		http.Error(w, "Unable to unmarshal json", http.StatusBadRequest)
+	}
+	data.AddDownload(dl)
+
+	d.l.Printf("Download: %#v", dl)
 }


### PR DESCRIPTION
## Summary
Introduces the ability to create new downloads via POST /downloads.

## Changes
- Added FromJSON method to the Download model for decoding request payloads
- Implemented AddDownload to set an incremental ID and default status (Queued)
- Updated Downloads HTTP handler to support POST in addition to GET
- POST logs new downloads and appends them to the in-memory store
- GID remains placeholder until aria2 integration

## Why
This completes the basic create/list cycle for the in-memory download store,
enabling manual testing of POST requests before connecting to the real downloader.

## Testing
Example curl:
curl -X POST http://localhost:9090/downloads \
  -H "Content-Type: application/json" \
  -d '{
        "source": "magnet:?xt=urn:btih:examplehash",
        "targetPath": "/movies/"
      }'

Then verify via GET /downloads that the new entry appears with a unique ID.