### PR TITLE
feat: Add PATCH /downloads/{id} for desiredStatus + clean routing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/downloads", downloadHandler)
+	serveMux.Handle("/downloads/", downloadHandler)
 
 	server := &http.Server{
 		Addr:         ":9090",


### PR DESCRIPTION
## Summary
Implements PATCH /downloads/{id} to update desiredStatus and finalizes basic
CRUD path for the in-memory store (GET list, POST create, PATCH desired state).

## Changes
- Downloads handler now routes /downloads and /downloads/{id} explicitly
- PATCH accepts {"desiredStatus":"Active|Paused|Cancelled"} and validates values
- Data layer: allowed desired statuses, UpdateDesiredStatus, FindByID helpers
- POST returns 201 Created and the created object (JSON)

## Why
This sets up the command surface (pause/resume/cancel) ahead of wiring a real
downloader. For now, desiredStatus mirrors into status to keep behavior visible.

## Testing
# list
curl http://localhost:9090/downloads

# create
curl -X POST http://localhost:9090/downloads \
  -H "Content-Type: application/json" \
  -d '{"source":"magnet:?xt=urn:btih:example","targetPath":"/movies/"}'

# pause
curl -X PATCH http://localhost:9090/downloads/1 \
  -H "Content-Type: application/json" \
  -d '{"desiredStatus":"Paused"}'

# resume
curl -X PATCH http://localhost:9090/downloads/1 \
  -H "Content-Type: application/json" \
  -d '{"desiredStatus":"Active"}'

# cancel
curl -X PATCH http://localhost:9090/downloads/1 \
  -H "Content-Type: application/json" \
  -d '{"desiredStatus":"Cancelled"}'