### PR TITLE
refactor: Refactor HTTP routing to use Gorilla Mux and split Download handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect


### PR DESCRIPTION
## Summary
This PR refactors the Torrus API routing layer to use Gorilla Mux instead of manual ServeHTTP logic, improving readability, maintainability, and route matching.

## Changes
- Added Gorilla Mux as the HTTP router
- Split Downloads handler into explicit methods:
  - GetDownloads — list all downloads
  - GetDownload — fetch single download by numeric ID
  - AddDownload — create a new download
  - UpdateDownload — update a download's desired status
- Updated main.go:
  - Registered each route with HTTP method constraints
  - Applied numeric regex for {id} path param in GET/PATCH routes
- Replaced manual `strings.HasPrefix` and `strconv.Atoi` parsing with `mux.Vars` for cleaner path param extraction
- Ensured all JSON responses set `Content-Type: application/json`

## Why
- Improves route handling by making method/URL mappings explicit
- Removes brittle string parsing for IDs
- Prepares for easier expansion as more routes are added