### PR TITLE
feat(logging): add request logging middleware to API (#15)

### DIFF
--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -1,0 +1,14 @@
+package handlers
+
+import "errors"
+
+var (
+	ErrDownloadCtx   = errors.New("download missing in context")
+	ErrDesiredStatus = errors.New("desired status missing in context")
+	ErrDesiredStatusJSON = errors.New("desired status is required")
+	ErrTargetPath = errors.New("targetPath is required")
+	ErrContentType = errors.New("Content-Type must be application/json")
+	ErrMagnetURI = errors.New("invalid magnet link")
+
+)
+

--- a/internal/handlers/middleware.go
+++ b/internal/handlers/middleware.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/tinoosan/torrus/internal/data"
+)
+
+func (d *Downloads) MiddlewareDownloadValidation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType := r.Header.Get("Content-Type"); contentType != "" && !strings.HasPrefix(contentType, "application/json") {
+			// Content type
+			markErr(w, ErrContentType)
+			http.Error(w, ErrContentType.Error(), http.StatusUnsupportedMediaType)
+			return
+		}
+
+		// Body limit
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
+		// Decode with strict fields
+		dl := &data.Download{}
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(dl); err != nil {
+			markErr(w, err)
+			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Field validation
+		if !isMagnet(dl.Source) {
+			markErr(w, ErrMagnetURI)
+			http.Error(w, ErrMagnetURI.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if strings.TrimSpace(dl.TargetPath) == "" {
+			markErr(w, ErrTargetPath)
+			http.Error(w, ErrTargetPath.Error(), http.StatusBadRequest)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), ctxKeyDownload{}, dl)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (d *Downloads) MiddlewarePatchDesired(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if contentType := r.Header.Get("Content-Type"); contentType != "" && !strings.HasPrefix(contentType, "application/json") {
+			markErr(w, ErrContentType)
+			http.Error(w, ErrContentType.Error(), http.StatusUnsupportedMediaType)
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
+		var body patchBody
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&body); err != nil {
+			markErr(w, err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if body.DesiredStatus == "" {
+			markErr(w, ErrDesiredStatusJSON)
+			http.Error(w, ErrDesiredStatusJSON.Error(), http.StatusBadRequest)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), ctxKeyPatch{}, body)
+		next.ServeHTTP(w, r.WithContext(ctx))
+
+	})
+}
+
+func (d *Downloads) Log(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+		rw := &rwLogger{ResponseWriter: w}
+		next.ServeHTTP(rw, r)
+		if rw.status == 0 {
+			rw.status = http.StatusOK
+		}
+		timeElapsed := time.Since(startTime)
+		hErr := rw.err
+		if hErr != nil {
+			d.l.Error(hErr.Error(),
+				"method", r.Method,
+				"url", r.URL.Path,
+				"status", rw.status,
+				"remote", r.RemoteAddr,
+				"ua", r.UserAgent(),
+				"dur_ms", timeElapsed.Milliseconds(),
+				"bytes", rw.bytes)
+			return
+		}
+
+		d.l.Info("", "method", r.Method,
+			"url", r.URL.Path,
+			"status", rw.status,
+			"remote", r.RemoteAddr,
+			"ua", r.UserAgent(),
+			"dur_ms", timeElapsed.Milliseconds(),
+			"bytes", rw.bytes)
+	})
+}
+
+func isMagnet(s string) bool {
+	if !strings.HasPrefix(s, "magnet:?") {
+		return false
+	}
+	return strings.Contains(s, "xt=urn:btih:")
+}


### PR DESCRIPTION
# feat(logging): add request logging middleware to API

## Description
This PR implements a request logging middleware that records HTTP method, path, status code, latency, and bytes written for all API requests.  
It also captures and logs handler errors via a `ResponseWriter` wrapper.

## Why
Without a wrapper like `rwLogger`, the default `http.ResponseWriter` doesn’t expose the final status code, byte count, or any error information after the handler runs.  
By introducing `rwLogger` and `markErr`:
- We can track exactly what the handler sent back (status + size).
- We can capture handler-level errors without changing every handler’s logging logic.
- The middleware remains reusable and non-intrusive for future endpoints.

## Changes
- Added `Log` middleware to `Downloads` handler.
- Created `rwLogger` wrapper to track status codes, response sizes, and errors.
- Integrated `markErr` helper to propagate handler errors into the middleware.
- Registered middleware globally in `main.go` router setup.

## Testing
- Sent requests via `curl` to multiple endpoints and confirmed logs include:
  - Method (`GET`, `POST`, etc.)
  - Path
  - Status code
  - Latency in ms
  - Bytes written
  - Address of the client that sent the request
  - User Agent of the client if available
- Verified error cases are logged at `ERROR` level with the correct message.

## Closes
Closes #15