### PR TITLE
feat(logging): add support for writing logs to file with stdout mirror

### DIFF
--- a/torrus.log
+++ b/torrus.log
@@ -1,0 +1,4 @@
+{"time":"2025-08-16T11:29:53.672167+01:00","level":"INFO","msg":"Starting Torrus API on","port":":9090"}
+{"time":"2025-08-16T11:31:13.24245+01:00","level":"INFO","msg":"","method":"POST","url":"/downloads","status":201,"remote":"[::1]:59547","ua":"curl/8.7.1","dur_ms":0,"bytes":212}
+{"time":"2025-08-22T12:46:57.438154+01:00","level":"INFO","msg":"Received terminate, graceful shutdown","signal":2}
+{"time":"2025-08-22T12:46:57.443013+01:00","level":"ERROR","msg":"Server error: %v","err":"http: Server closed"}


### PR DESCRIPTION
## Summary

This PR adds the ability to persist logs to a file while still streaming them to stdout.

### Changes
- Added file logging (`torrus.log`) in append mode.
- Combined file + stdout output with `io.MultiWriter`.
- Maintained configurable log format via `LOG_FORMAT` env var (`text` or `json`).
- Ensured file handle is closed on shutdown.

### Testing
- Verified logs appear both in `torrus.log` and stdout.
- Tested with both text and JSON formats by toggling `LOG_FORMAT`.
- Confirmed no blocking/hanging issues when writing concurrently.

### Next Steps
- Implement log rotation to prevent `torrus.log` from growing indefinitely.
- Consider log levels and per-component logging in the future.