### PR TITLE
 feat(api): introduce versioning with /v1 prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,41 @@ Torrus is a work-in-progress API for managing and monitoring downloads.
 - Update download state
 - Retrieve download details
 
+## Versioning Policy
+All API endpoints are explicitly versioned starting with **v1**.  
+Future breaking changes will be introduced under a new version (e.g., `/v2/...`).  
+Unversioned endpoints are disabled by default to encourage consistent usage.
+
+- Current version: **v1**
+- Unversioned routes: return `404` (or may optionally redirect to `/v1/...`)
+- Futre health check endpoints (e.g., `/healthz`) will remain unversioned
+
+## Endpoints (v1)
+
+### Downloads
+- `GET    /v1/downloads` → List downloads
+- `GET    /v1/downloads/{id}` → Retrieve a single download
+- `POST   /v1/downloads` → Create a new download
+- `PATCH  /v1/downloads/{id}` → Update download state
+
+### Health
+- `GET    /healthz` → Service health check (unversioned)
+
+## Example Requests
+
+```bash
+# List downloads
+curl http://localhost:8080/v1/downloads
+
+# Get a download by ID
+curl http://localhost:8080/v1/downloads/123
+
+# Create a new download
+curl -X POST http://localhost:8080/v1/downloads \
+  -H "Content-Type: application/json" \
+  -d '{"url": "magnet:?xt=urn:btih:..."}'
+
+# Update download state
+curl -X PATCH http://localhost:8080/v1/downloads/123 \
+  -H "Content-Type: application/json" \
+  -d '{"status": "paused"}'

--- a/api/v1/errors.go
+++ b/api/v1/errors.go
@@ -1,4 +1,4 @@
-package handlers
+package v1
 
 import "errors"
 

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -1,4 +1,4 @@
-package handlers
+package v1
 
 import (
 	"log/slog"

--- a/api/v1/middleware.go
+++ b/api/v1/middleware.go
@@ -1,4 +1,4 @@
-package handlers
+package v1
 
 import (
 	"context"

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -1,0 +1,36 @@
+package router
+
+import (
+	"log/slog"
+
+	"github.com/gorilla/mux"
+	v1 "github.com/tinoosan/torrus/api/v1"
+)
+
+func New(logger *slog.Logger) *mux.Router {
+
+	r := mux.NewRouter()
+
+	downloadHandler := v1.NewDownloads(logger)
+
+	r.Use(downloadHandler.Log)
+
+	api := r.PathPrefix("/v1").Subrouter()
+
+	// GETs
+	get := api.Methods("GET").Subrouter()
+	get.HandleFunc("/downloads", downloadHandler.GetDownloads)
+	get.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.GetDownload)
+
+	// POSTs
+	post := api.Methods("POST").Subrouter()
+	post.HandleFunc("/downloads", downloadHandler.AddDownload)
+	post.Use(downloadHandler.MiddlewareDownloadValidation)
+
+	// PATCHes
+	patch := api.Methods("PATCH").Subrouter()
+	patch.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.UpdateDownload)
+	patch.Use(downloadHandler.MiddlewarePatchDesired)
+
+	return r
+}


### PR DESCRIPTION
## Description

This PR introduces explicit API versioning by serving all endpoints under the `/v1` path.  
It ensures future breaking changes can be introduced safely without disrupting existing clients.

## Why

Versioning provides a clear contract for clients and prevents accidental breakage when the API evolves.  
Starting with `/v1` allows us to add `/v2` later while maintaining backward compatibility.

## Changes

- Added Gorilla subrouter under `/v1`.
- Moved all existing routes (`GET/POST/PATCH downloads`) to `/v1/...`.
- Disabled unversioned routes (return `404`).
- Updated `README.md`:
  - Documented versioning policy.
  - Updated examples to use `/v1`.

## Testing

- Verified with `curl` and Postman:
  - `GET /v1/downloads` returns list.
  - `GET /v1/downloads/{id}` returns details.
  - `POST /v1/downloads` creates download.
  - `PATCH /v1/downloads/{id}` updates download.
- Confirmed unversioned routes return `404`.

## Notes

- Future breaking changes will be added under `/v2`.
- Strict mode only — no redirects for unversioned routes.

Closes #26 