### PR TITLE
feat(api): add /healthz endpoint

### DIFF
--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"log/slog"
+	"net/http"
 
 	"github.com/gorilla/mux"
 	v1 "github.com/tinoosan/torrus/api/v1"
@@ -10,6 +11,10 @@ import (
 func New(logger *slog.Logger) *mux.Router {
 
 	r := mux.NewRouter()
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}).Methods("GET")
 
 	downloadHandler := v1.NewDownloads(logger)
 


### PR DESCRIPTION
## Description
Adds a new unversioned /healthz endpoint to the Torrus API.  
This endpoint provides a simple way for load balancers, monitoring systems, and developers to confirm the service is alive.  

## Why
Health checks are a standard requirement in APIs and services.  
They allow external systems (e.g., Kubernetes, Docker, monitoring tools) to verify if the service is running without needing authentication or version-specific logic.

## Changes
- Added `/healthz` route to the main router.
- Endpoint returns `200 OK` with body `ok`.
- Ensured `/healthz` bypasses authentication middleware.
- Updated README:
  - Added **Health** section under Endpoints.
  - Clarified that `/healthz` remains unversioned in the versioning policy.

## Testing
- Ran `curl http://localhost:9090/healthz`
  - Confirmed `200 OK` response.
  - Response body is `ok`.
- Verified `/healthz` does not require authentication.

## Notes
- Endpoint is intentionally simple (no DB or dependency checks).
- Future improvements could include extended checks (DB, cache, external services).

## Closes
Closes #28 