### PR TITLE
fix(repo): prevent data races by returning deep copies

### DIFF
--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -45,5 +45,23 @@ func (d *Download) ToJSON(w io.Writer) error { return json.NewEncoder(w).Encode(
 
 func (d *Download) FromJSON(r io.Reader) error { return json.NewDecoder(r).Decode(d) }
 
+func (d *Download) Clone() *Download {
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	return &cp
+}
+
+func (ds Downloads) Clone() Downloads {
+	out := make(Downloads, len(ds))
+	for i, d := range ds {
+		if d != nil {
+			cp := *d
+			out[i] = &cp
+		}
+	}
+	return out
+}
 func ParseID(s string) (int, error) { return strconv.Atoi(s) }
 

--- a/internal/repo/inmem.go
+++ b/internal/repo/inmem.go
@@ -24,9 +24,7 @@ func NewInMemoryDownloadRepo() *InMemoryDownloadRepo {
 func (r *InMemoryDownloadRepo) List(ctx context.Context) data.Downloads {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	out := make(data.Downloads, len(r.downloads))
-	copy(out, r.downloads)
-	return out
+	return r.downloads.Clone()
 }
 
 func (r *InMemoryDownloadRepo) Get(ctx context.Context, id int) (*data.Download, error) {
@@ -34,7 +32,7 @@ func (r *InMemoryDownloadRepo) Get(ctx context.Context, id int) (*data.Download,
 	defer r.mu.RUnlock()
 	for _, d := range r.downloads {
 		if d.ID == id {
-			return d, nil
+			return d.Clone(), nil
 		}
 	}
 	return nil, data.ErrNotFound
@@ -51,7 +49,7 @@ func (r *InMemoryDownloadRepo) Add(ctx context.Context, d *data.Download) (*data
 	d.DesiredStatus = data.StatusQueued
 	d.Status = data.StatusQueued
 	r.downloads = append(r.downloads, d)
-	return d, nil
+	return d.Clone() , nil
 }
 
 func (r *InMemoryDownloadRepo) UpdateDesiredStatus(ctx context.Context, id int, status data.DownloadStatus) (*data.Download, error) {
@@ -65,7 +63,7 @@ func (r *InMemoryDownloadRepo) UpdateDesiredStatus(ctx context.Context, id int, 
 		return nil, err
 	}
 	dl.DesiredStatus = status
-	return dl, nil
+	return dl.Clone(), nil
 }
 
 func (r *InMemoryDownloadRepo) findByID(id int) (*data.Download, error) {

--- a/internal/repo/inmem_test.go
+++ b/internal/repo/inmem_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -95,8 +96,10 @@ func TestInMemoryDownloadRepo_Get(t *testing.T) {
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("expected error %v got %v", tt.wantErr, err)
 			}
-			if tt.wantErr == nil && got != tt.want {
-				t.Fatalf("expected download %v got %v", tt.want, got)
+			if tt.wantErr == nil {
+				if !reflect.DeepEqual(*got, *tt.want) {
+					t.Fatalf("mismatch:\n got:  %#v\n want: %#v", got, tt.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Updated repo tests to compare Download values (reflect.DeepEqual) rather than pointer identity.
- Ensures List() and Get() correctly return deep copies instead of leaking internal pointers.
- Confirms Add() and UpdateDesiredStatus() also return cloned values.

Relates to #38 (deep copy fix).