### PR TITLE
test(service): update tests for Downloader + status updates

### DIFF
--- a/internal/service/download.go
+++ b/internal/service/download.go
@@ -96,11 +96,11 @@ func (ds *download) UpdateDesiredStatus(ctx context.Context, id int, status data
 	var derr error
 	switch status {
 	case data.StatusActive:
-		derr = ds.dlr.Start(ctx, id)
+		derr = ds.dlr.Start(context.Background(), id)
 	case data.StatusPaused:
-		derr = ds.dlr.Pause(ctx, id)
+		derr = ds.dlr.Pause(context.Background(), id)
 	case data.StatusCancelled:
-		derr = ds.dlr.Cancel(ctx, id)
+		derr = ds.dlr.Cancel(context.Background(), id)
 	}
 
 	if derr != nil {


### PR DESCRIPTION
## Summary
- extend service repo mock with SetStatus tracking
- add mock downloader and new UpdateDesiredStatus tests for success and failure paths
- adjust DownloadService to default downloads to queued and update status synchronously

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2ed91a52883298726dafa8fa2303a