### PR TITLE
refactor(downloader): accept full Download object instead of ID

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,10 +2,12 @@ package downloader
 
 import (
 	"context"
+
+	"github.com/tinoosan/torrus/internal/data"
 )
 
 type Downloader interface {
-	Start(ctx context.Context, id int) error
-	Pause(ctx context.Context, id int) error
-	Cancel(ctx context.Context, id int) error
+	Start(ctx context.Context, d *data.Download) error
+	Pause(ctx context.Context, d *data.Download) error
+	Cancel(ctx context.Context, d *data.Download) error
 }

--- a/internal/downloader/noop.go
+++ b/internal/downloader/noop.go
@@ -3,6 +3,8 @@ package downloader
 import (
 	"context"
 	"fmt"
+
+	"github.com/tinoosan/torrus/internal/data"
 )
 
 type noopDownloader struct {}
@@ -11,25 +13,19 @@ func NewNoopDownloader() Downloader {
 	return &noopDownloader{}
 }
 
-func (d *noopDownloader) Start(ctx context.Context, id int) error {
-	fmt.Println("noop: start", id)
+func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) error {
+	fmt.Println("noop: start", dl.ID)
 	return nil
 }
 
 
-func (d *noopDownloader) Resume(ctx context.Context, id int) error {
-	fmt.Println("noop: resume", id)
+func (d *noopDownloader) Pause(ctx context.Context, dl *data.Download) error {
+	fmt.Println("noop: pause", dl.ID)
 	return nil
 }
 
 
-func (d *noopDownloader) Pause(ctx context.Context, id int) error {
-	fmt.Println("noop: pause", id)
-	return nil
-}
-
-
-func (d *noopDownloader) Cancel(ctx context.Context, id int) error {
-	fmt.Println("noop: cancel", id)
+func (d *noopDownloader) Cancel(ctx context.Context, dl *data.Download) error {
+	fmt.Println("noop: cancel", dl.ID)
 	return nil
 }

--- a/internal/service/download.go
+++ b/internal/service/download.go
@@ -78,7 +78,7 @@ func (ds *download) Add(ctx context.Context, d *data.Download) (*data.Download, 
 
 	if saved.Status == data.StatusActive {
 		go func(id int) {
-			_ = ds.dlr.Start(context.Background(), id)
+			_ = ds.dlr.Start(context.Background(), saved)
 		}(saved.ID)
 	}
 	return saved, nil
@@ -96,11 +96,11 @@ func (ds *download) UpdateDesiredStatus(ctx context.Context, id int, status data
 	var derr error
 	switch status {
 	case data.StatusActive:
-		derr = ds.dlr.Start(context.Background(), id)
+		derr = ds.dlr.Start(context.Background(), d)
 	case data.StatusPaused:
-		derr = ds.dlr.Pause(context.Background(), id)
+		derr = ds.dlr.Pause(context.Background(), d)
 	case data.StatusCancelled:
-		derr = ds.dlr.Cancel(context.Background(), id)
+		derr = ds.dlr.Cancel(context.Background(), d)
 	}
 
 	if derr != nil {

--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -18,7 +18,7 @@ type mockDownloadRepo struct {
 	addFn    func(ctx context.Context, d *data.Download) (*data.Download, error)
 	updateFn func(ctx context.Context, id int, status data.DownloadStatus) (*data.Download, error)
 	setFn    func(ctx context.Context, id int, status data.DownloadStatus) error
-	setGIDFn    func(ctx context.Context, id int, gid string) error
+	setGIDFn func(ctx context.Context, id int, gid string) error
 
 	listCalled   bool
 	getCalled    bool
@@ -29,9 +29,8 @@ type mockDownloadRepo struct {
 
 	setArgs struct {
 		id     int
-		gid string
+		gid    string
 		status data.DownloadStatus
-
 	}
 }
 
@@ -39,31 +38,31 @@ var _ repo.DownloadRepo = (*mockDownloadRepo)(nil)
 
 type mockDownloader struct {
 	startCalled, pauseCalled, cancelCalled bool
-	startFn                                func(ctx context.Context, id int) error
-	pauseFn                                func(ctx context.Context, id int) error
-	cancelFn                               func(ctx context.Context, id int) error
+	startFn                                func(ctx context.Context, dl *data.Download) error
+	pauseFn                                func(ctx context.Context, dl *data.Download) error
+	cancelFn                               func(ctx context.Context, dl *data.Download) error
 }
 
-func (m *mockDownloader) Start(ctx context.Context, id int) error {
+func (m *mockDownloader) Start(ctx context.Context, dl *data.Download) error {
 	m.startCalled = true
 	if m.startFn != nil {
-		return m.startFn(ctx, id)
+		return m.startFn(ctx, dl)
 	}
 	return nil
 }
 
-func (m *mockDownloader) Pause(ctx context.Context, id int) error {
+func (m *mockDownloader) Pause(ctx context.Context, dl *data.Download) error {
 	m.pauseCalled = true
 	if m.pauseFn != nil {
-		return m.pauseFn(ctx, id)
+		return m.pauseFn(ctx, dl)
 	}
 	return nil
 }
 
-func (m *mockDownloader) Cancel(ctx context.Context, id int) error {
+func (m *mockDownloader) Cancel(ctx context.Context, dl *data.Download) error {
 	m.cancelCalled = true
 	if m.cancelFn != nil {
-		return m.cancelFn(ctx, id)
+		return m.cancelFn(ctx, dl)
 	}
 	return nil
 }
@@ -121,7 +120,6 @@ func (m *mockDownloadRepo) SetGID(ctx context.Context, id int, gid string) error
 	}
 	return nil
 }
-
 
 func TestDownloadService_List(t *testing.T) {
 	ctx := context.Background()
@@ -376,7 +374,7 @@ func TestDownloadService_UpdateDesiredStatus(t *testing.T) {
 			},
 		}
 		mDL := &mockDownloader{
-			startFn: func(ctx context.Context, id int) error { return errors.New("boom") },
+			startFn: func(ctx context.Context, dl *data.Download) error { return errors.New("boom") },
 		}
 
 		svc := NewDownload(mRepo, mDL)


### PR DESCRIPTION
Update Downloader interface methods (Start, Pause, Cancel) to take a *data.Download
instead of just an ID. This allows implementations (noop, aria2, etc.) to directly
access both ID and TargetPath/source when performing operations.

BREAKING CHANGE: existing implementations updated to match new signature.