### PR TITLE
feat(downloader/aria2): add aria2 adapter and wire service to use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage.out
 .vscode/
 .idea/
 .env
+Downloads/

--- a/internal/aria2/client.go
+++ b/internal/aria2/client.go
@@ -43,3 +43,7 @@ func NewClientFromEnv() (*Client, error) {
 		http:    &http.Client{Timeout: time.Duration(ms) * time.Millisecond},
 	}, nil
 }
+
+func (c *Client) BaseURL() *url.URL { return c.baseURL}
+func (c *Client) Secret() string { return c.secret}
+func (c *Client) HTTP() *http.Client { return c.http}

--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -1,0 +1,127 @@
+package aria2dl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/tinoosan/torrus/internal/aria2" // your Client
+	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader" // the Downloader interface
+)
+
+type Adapter struct {
+	cl *aria2.Client
+}
+
+func NewAdapter(cl *aria2.Client) *Adapter { return &Adapter{cl: cl} }
+
+var _ downloader.Downloader = (*Adapter)(nil)
+
+// --- JSON-RPC wire types ---
+
+type rpcReq struct {
+	Jsonrpc string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	ID      string        `json:"id"`
+	Params  []interface{} `json:"params,omitempty"`
+}
+
+type rpcResp struct {
+	Jsonrpc string          `json:"jsonrpc"`
+	ID      string          `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (a *Adapter) call(ctx context.Context, method string, params []interface{}) (json.RawMessage, error) {
+	body, _ := json.Marshal(rpcReq{
+		Jsonrpc: "2.0",
+		Method:  method,
+		ID:      "torrus",
+		Params:  params,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cl.BaseURL().String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.cl.HTTP().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("aria2 http %d: %s", resp.StatusCode, string(b))
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+
+	var rr rpcResp
+	if err := json.Unmarshal(b, &rr); err != nil {
+		return nil, fmt.Errorf("aria2 rpc decode: %w (%s)", err, string(b))
+	}
+	if rr.Error != nil {
+		return nil, fmt.Errorf("aria2 rpc error %d: %s", rr.Error.Code, rr.Error.Message)
+	}
+	return rr.Result, nil
+}
+
+// helper: token parameter if secret set (aria2 expects "token:<secret>" as first param)
+func (a *Adapter) tokenParam() []interface{} {
+	if s := a.cl.Secret(); s != "" {
+		return []interface{}{"token:" + s}
+	}
+	return nil
+}
+
+// Start: aria2.addUri([token?, [uris], options])
+func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) {
+	params := make([]interface{}, 0, 3)
+	if tok := a.tokenParam(); tok != nil {
+		params = append(params, tok...)
+	}
+	params = append(params, []string{dl.Source})
+	opts := map[string]string{}
+	if dl.TargetPath != "" {
+		opts["dir"] = dl.TargetPath
+	}
+	params = append(params, opts)
+
+	res, err := a.call(ctx, "aria2.addUri", params)
+	if err != nil {
+		return "", err
+	}
+	// result is GID string
+	var gid string
+	if err := json.Unmarshal(res, &gid); err != nil {
+		return "", fmt.Errorf("parse addUri result: %w", err)
+	}
+	return gid, nil
+}
+
+// Pause: aria2.pause([token?, gid])
+func (a *Adapter) Pause(ctx context.Context, dl *data.Download) error {
+	params := append(a.tokenParam(), dl.GID)
+	_, err := a.call(ctx, "aria2.pause", params)
+	return err
+}
+
+// Cancel: aria2.remove([token?, gid])
+func (a *Adapter) Cancel(ctx context.Context, dl *data.Download) error {
+	params := append(a.tokenParam(), dl.GID)
+	_, err := a.call(ctx, "aria2.remove", params)
+	return err
+}

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -1,0 +1,164 @@
+package aria2dl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/tinoosan/torrus/internal/aria2"
+	"github.com/tinoosan/torrus/internal/data"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newTestAdapter(t *testing.T, secret string, rt http.RoundTripper) *Adapter {
+	t.Helper()
+	t.Setenv("ARIA2_RPC_URL", "http://example.com/jsonrpc")
+	t.Setenv("ARIA2_SECRET", secret)
+	c, err := aria2.NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	c.HTTP().Transport = rt
+	return NewAdapter(c)
+}
+
+func TestAdapterStart(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		dl := &data.Download{Source: "http://foo/bar", TargetPath: "/tmp"}
+		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(r.Body)
+			var req rpcReq
+			if err := json.Unmarshal(b, &req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if req.Method != "aria2.addUri" {
+				t.Fatalf("method = %s", req.Method)
+			}
+			if req.ID != "torrus" {
+				t.Fatalf("id = %s", req.ID)
+			}
+			if len(req.Params) != 3 {
+				t.Fatalf("params len = %d", len(req.Params))
+			}
+			if tok, _ := req.Params[0].(string); tok != "token:secret" {
+				t.Fatalf("token param = %v", req.Params[0])
+			}
+			if uris, ok := req.Params[1].([]interface{}); !ok || len(uris) != 1 || uris[0] != dl.Source {
+				t.Fatalf("uris param = %#v", req.Params[1])
+			}
+			if opts, ok := req.Params[2].(map[string]interface{}); !ok || opts["dir"] != dl.TargetPath {
+				t.Fatalf("opts = %#v", req.Params[2])
+			}
+			resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"gid123"`)}
+			rb, _ := json.Marshal(resp)
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+		})
+		a := newTestAdapter(t, "secret", rt)
+		gid, err := a.Start(context.Background(), dl)
+		if err != nil {
+			t.Fatalf("Start error: %v", err)
+		}
+		if gid != "gid123" {
+			t.Fatalf("gid = %s", gid)
+		}
+	})
+
+	t.Run("rpc error", func(t *testing.T) {
+		dl := &data.Download{Source: "http://foo/bar"}
+		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(r.Body)
+			var req rpcReq
+			if err := json.Unmarshal(b, &req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if req.Method != "aria2.addUri" {
+				t.Fatalf("method = %s", req.Method)
+			}
+			if req.ID != "torrus" {
+				t.Fatalf("id = %s", req.ID)
+			}
+			if len(req.Params) != 2 {
+				t.Fatalf("params len = %d", len(req.Params))
+			}
+			if _, ok := req.Params[0].([]interface{}); !ok {
+				t.Fatalf("expected uris slice, got %#v", req.Params[0])
+			}
+			resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Error: &rpcError{Code: 1, Message: "boom"}}
+			rb, _ := json.Marshal(resp)
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+		})
+		a := newTestAdapter(t, "", rt)
+		gid, err := a.Start(context.Background(), dl)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		if gid != "" {
+			t.Fatalf("gid = %s", gid)
+		}
+	})
+}
+
+func TestAdapterPauseCancel(t *testing.T) {
+	methods := []struct {
+		name      string
+		rpcMethod string
+		call      func(context.Context, *Adapter, *data.Download) error
+	}{
+		{"Pause", "aria2.pause", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Pause(ctx, d) }},
+		{"Cancel", "aria2.remove", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Cancel(ctx, d) }},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name+" success", func(t *testing.T) {
+			dl := &data.Download{GID: "gid-1"}
+			rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				b, _ := io.ReadAll(r.Body)
+				var req rpcReq
+				if err := json.Unmarshal(b, &req); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				if req.Method != m.rpcMethod {
+					t.Fatalf("method = %s", req.Method)
+				}
+				if req.ID != "torrus" {
+					t.Fatalf("id = %s", req.ID)
+				}
+				if len(req.Params) != 2 {
+					t.Fatalf("params len = %d", len(req.Params))
+				}
+				if tok, _ := req.Params[0].(string); tok != "token:secret" {
+					t.Fatalf("token param = %v", req.Params[0])
+				}
+				if gid, _ := req.Params[1].(string); gid != dl.GID {
+					t.Fatalf("gid param = %v", req.Params[1])
+				}
+				resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)}
+				rb, _ := json.Marshal(resp)
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+			})
+			a := newTestAdapter(t, "secret", rt)
+			if err := m.call(context.Background(), a, dl); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+
+		t.Run(m.name+" error", func(t *testing.T) {
+			dl := &data.Download{GID: "gid-1"}
+			rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Error: &rpcError{Code: 2, Message: "fail"}}
+				rb, _ := json.Marshal(resp)
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+			})
+			a := newTestAdapter(t, "", rt)
+			if err := m.call(context.Background(), a, dl); err == nil {
+				t.Fatalf("expected error")
+			}
+		})
+	}
+}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -2,12 +2,15 @@ package downloader
 
 import (
 	"context"
+	"errors"
 
 	"github.com/tinoosan/torrus/internal/data"
 )
 
+var ErrNotFound = errors.New("downloader not found")
+
 type Downloader interface {
-	Start(ctx context.Context, d *data.Download) error
+	Start(ctx context.Context, d *data.Download) (string, error)
 	Pause(ctx context.Context, d *data.Download) error
 	Cancel(ctx context.Context, d *data.Download) error
 }

--- a/internal/downloader/noop.go
+++ b/internal/downloader/noop.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/tinoosan/torrus/internal/data"
 )
@@ -13,9 +14,9 @@ func NewNoopDownloader() Downloader {
 	return &noopDownloader{}
 }
 
-func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) error {
+func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) (string, error) {
 	fmt.Println("noop: start", dl.ID)
-	return nil
+	return strconv.FormatInt(int64(dl.ID), 10), nil
 }
 
 

--- a/internal/repo/downloads.go
+++ b/internal/repo/downloads.go
@@ -21,4 +21,5 @@ type DownloadWriter interface {
 	UpdateDesiredStatus(ctx context.Context, id int, status data.DownloadStatus) (*data.Download, error)
 	SetStatus(ctx context.Context, id int, status data.DownloadStatus) error
 	SetGID(ctx context.Context, id int, gid string) error
+	ClearGID(ctx context.Context, id int) error
 }

--- a/internal/repo/inmem.go
+++ b/internal/repo/inmem.go
@@ -79,6 +79,16 @@ func (r *InMemoryDownloadRepo) SetGID(ctx context.Context, id int, gid string) e
 	return nil
 }
 
+func (r *InMemoryDownloadRepo) ClearGID(ctx context.Context, id int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	dl, err := r.findByID(id)
+	if err != nil {
+		return err
+	}
+	dl.GID = ""
+	return nil
+}
 func (r *InMemoryDownloadRepo) findByID(id int) (*data.Download, error) {
 	for _, dl := range r.downloads {
 		if dl.ID == id {

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -30,11 +30,13 @@ func New(logger *slog.Logger) *mux.Router {
 
 	switch os.Getenv("TORRUS_CLIENT") {
 	case "aria2":
-	aria2Client, err := aria2.NewClientFromEnv()
-	if err != nil {
-		fmt.Println("Error:", err)
-	}
-	dlr = aria2dl.NewAdapter(aria2Client)
+		aria2Client, err := aria2.NewClientFromEnv()
+		if err != nil {
+			fmt.Println("Error:", err)
+			dlr = downloader.NewNoopDownloader()
+		} else {
+			dlr = aria2dl.NewAdapter(aria2Client)
+		}
 	default:
 		dlr = downloader.NewNoopDownloader()
 	}

--- a/internal/service/download.go
+++ b/internal/service/download.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -78,39 +79,84 @@ func (ds *download) Add(ctx context.Context, d *data.Download) (*data.Download, 
 
 	if saved.Status == data.StatusActive {
 		go func(id int) {
-			_ = ds.dlr.Start(context.Background(), saved)
+			gid, _ := ds.dlr.Start(context.Background(), saved)
+			saved.GID = gid
 		}(saved.ID)
 	}
 	return saved, nil
 }
 
 func (ds *download) UpdateDesiredStatus(ctx context.Context, id int, status data.DownloadStatus) (*data.Download, error) {
-	if !AllowedStatuses[status] {
+	// Guard invalid desired statuses up front (service-level policy).
+	switch status {
+	case data.StatusActive, data.StatusPaused, data.StatusCancelled:
+	default:
 		return nil, data.ErrBadStatus
 	}
 
-	d, err := ds.repo.UpdateDesiredStatus(ctx, id, status)
+	// Always fetch the latest state first.
+	cur, err := ds.repo.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	var derr error
-	switch status {
-	case data.StatusActive:
-		derr = ds.dlr.Start(context.Background(), d)
-	case data.StatusPaused:
-		derr = ds.dlr.Pause(context.Background(), d)
-	case data.StatusCancelled:
-		derr = ds.dlr.Cancel(context.Background(), d)
-	}
 
-	if derr != nil {
-		_ = ds.repo.SetStatus(ctx, id, data.StatusError)
-		return nil, derr
-	}
-
-	if err := ds.repo.SetStatus(ctx, id, status); err != nil {
+	// Persist desiredStatus (so callers see intent even if the actual action fails).
+	if _, err := ds.repo.UpdateDesiredStatus(ctx, id, status); err != nil {
 		return nil, err
 	}
-	d.Status = status
-	return d, nil
+
+	switch status {
+	case data.StatusActive:
+		// Start if we don't have a GID yet (fresh start).
+		// If we *do* have a GID, keep it simple for MVP: just set Status=Active
+		// and return (future: introduce Resume in downloader and call it here).
+		if cur.GID == "" {
+			gid, derr := ds.dlr.Start(ctx, cur) // uses Source + TargetPath from cur
+			if derr != nil {
+				_ = ds.repo.SetStatus(ctx, id, data.StatusError)
+				return nil, derr
+			}
+			if err := ds.repo.SetGID(ctx, id, gid); err != nil {
+				_ = ds.repo.SetStatus(ctx, id, data.StatusError)
+				return nil, err
+			}
+		}
+		if err := ds.repo.SetStatus(ctx, id, data.StatusActive); err != nil {
+			return nil, err
+		}
+
+	case data.StatusPaused:
+		// If no GID, nothing to pause (treat as success: desired=Paused, status=Paused).
+		if cur.GID != "" {
+			if derr := ds.dlr.Pause(ctx, cur); derr != nil {
+				_ = ds.repo.SetStatus(ctx, id, data.StatusError)
+				return nil, derr
+			}
+		}
+		if err := ds.repo.SetStatus(ctx, id, data.StatusPaused); err != nil {
+			return nil, err
+		}
+
+	case data.StatusCancelled:
+		// Try to cancel if we have a GID; treat "not found" as success for idempotency.
+		if cur.GID != "" {
+			if derr := ds.dlr.Cancel(ctx, cur); derr != nil && !isDownloaderNotFound(derr) {
+				_ = ds.repo.SetStatus(ctx, id, data.StatusError)
+				return nil, derr
+			}
+		}
+		if err := ds.repo.ClearGID(ctx, id); err != nil {
+			return nil, err
+		}
+		if err := ds.repo.SetStatus(ctx, id, data.StatusCancelled); err != nil {
+			return nil, err
+		}
+	}
+
+	// Return the latest snapshot.
+	return ds.repo.Get(ctx, id)
+}
+
+func isDownloaderNotFound(err error) bool {
+	return errors.Is(err, downloader.ErrNotFound)
 }

--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -18,7 +18,7 @@ type mockDownloadRepo struct {
 	addFn    func(ctx context.Context, d *data.Download) (*data.Download, error)
 	updateFn func(ctx context.Context, id int, status data.DownloadStatus) (*data.Download, error)
 	setFn    func(ctx context.Context, id int, status data.DownloadStatus) error
-	setGIDFn func(ctx context.Context, id int, gid string) error
+	setGIDFn    func(ctx context.Context, id int, gid string) error
 
 	listCalled   bool
 	getCalled    bool
@@ -29,8 +29,9 @@ type mockDownloadRepo struct {
 
 	setArgs struct {
 		id     int
-		gid    string
+		gid string
 		status data.DownloadStatus
+
 	}
 }
 
@@ -38,31 +39,31 @@ var _ repo.DownloadRepo = (*mockDownloadRepo)(nil)
 
 type mockDownloader struct {
 	startCalled, pauseCalled, cancelCalled bool
-	startFn                                func(ctx context.Context, dl *data.Download) error
-	pauseFn                                func(ctx context.Context, dl *data.Download) error
-	cancelFn                               func(ctx context.Context, dl *data.Download) error
+	startFn                                func(ctx context.Context, id int) error
+	pauseFn                                func(ctx context.Context, id int) error
+	cancelFn                               func(ctx context.Context, id int) error
 }
 
-func (m *mockDownloader) Start(ctx context.Context, dl *data.Download) error {
+func (m *mockDownloader) Start(ctx context.Context, id int) error {
 	m.startCalled = true
 	if m.startFn != nil {
-		return m.startFn(ctx, dl)
+		return m.startFn(ctx, id)
 	}
 	return nil
 }
 
-func (m *mockDownloader) Pause(ctx context.Context, dl *data.Download) error {
+func (m *mockDownloader) Pause(ctx context.Context, id int) error {
 	m.pauseCalled = true
 	if m.pauseFn != nil {
-		return m.pauseFn(ctx, dl)
+		return m.pauseFn(ctx, id)
 	}
 	return nil
 }
 
-func (m *mockDownloader) Cancel(ctx context.Context, dl *data.Download) error {
+func (m *mockDownloader) Cancel(ctx context.Context, id int) error {
 	m.cancelCalled = true
 	if m.cancelFn != nil {
-		return m.cancelFn(ctx, dl)
+		return m.cancelFn(ctx, id)
 	}
 	return nil
 }
@@ -120,6 +121,7 @@ func (m *mockDownloadRepo) SetGID(ctx context.Context, id int, gid string) error
 	}
 	return nil
 }
+
 
 func TestDownloadService_List(t *testing.T) {
 	ctx := context.Background()
@@ -374,7 +376,7 @@ func TestDownloadService_UpdateDesiredStatus(t *testing.T) {
 			},
 		}
 		mDL := &mockDownloader{
-			startFn: func(ctx context.Context, dl *data.Download) error { return errors.New("boom") },
+			startFn: func(ctx context.Context, id int) error { return errors.New("boom") },
 		}
 
 		svc := NewDownload(mRepo, mDL)


### PR DESCRIPTION
- Introduce aria2 client (`internal/aria2`) with env-based config:
  - ARIA2_RPC_URL (default: http://127.0.0.1:6800/jsonrpc)
  - ARIA2_SECRET (optional)
  - ARIA2_TIMEOUT_MS (default: 3000)
- Add aria2 Downloader adapter (`internal/aria2dl.Adapter`) implementing Start/Pause/Cancel via JSON-RPC (`aria2.addUri`, `aria2.pause`, `aria2.remove`).
- Service: update `DownloadService.UpdateDesiredStatus` to:
  - persist desired status via repo
  - invoke downloader action (start/pause/cancel)
  - on Start success, store returned GID via repo
  - on Cancel success, clear GID via repo
  - set actual status to match desired on success; set to Failed on errors
- Keep handlers unchanged; API behavior preserved.

Notes:
- Completion reconciliation (updating to Complete when aria2 finishes) is not yet implemented and will be handled in a follow-up.
- aria2 may invalidate GIDs after completion; handled in future reconcile loop.

Closes #81