### PR TITLE
fix: persist aria2 GIDs and update mocks

### DIFF
--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -30,11 +30,13 @@ func New(logger *slog.Logger) *mux.Router {
 
 	switch os.Getenv("TORRUS_CLIENT") {
 	case "aria2":
-	aria2Client, err := aria2.NewClientFromEnv()
-	if err != nil {
-		fmt.Println("Error:", err)
-	}
-	dlr = aria2dl.NewAdapter(aria2Client)
+		aria2Client, err := aria2.NewClientFromEnv()
+		if err != nil {
+			fmt.Println("Error:", err)
+			dlr = downloader.NewNoopDownloader()
+		} else {
+			dlr = aria2dl.NewAdapter(aria2Client)
+		}
 	default:
 		dlr = downloader.NewNoopDownloader()
 	}


### PR DESCRIPTION
## Summary
- persist GID when starting active downloads and handle errors
- guard against nil aria2 client by falling back to noop downloader
- update service tests and mocks for new downloader/repo interfaces

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68b339ee51508329b40fad55c12b1494