### PR TITLE
ci: extend pipeline with lint + integration jobs

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,82 @@
+name: Integration (compose)
+on:
+  pull_request:
+    branches: [ dev, main ]
+  push:
+    branches: [ dev ]
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:24-dind
+        privileged: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build app image (local)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          load: true
+          tags: torrus-api:ci
+
+      - name: Create .env for compose
+        run: |
+          cat > .env <<EOF
+          LOG_FORMAT=json
+          LOG_FILE_PATH=./logs/torrus.log
+          LOG_MAX_SIZE=5
+          LOG_MAX_BACKUPS=2
+          LOG_MAX_AGE_DAYS=7
+
+          ARIA2_RPC_URL=http://aria2:6800/jsonrpc
+          ARIA2_SECRET=ci-secret
+          ARIA2_TIMEOUT_MS=5000
+          EOF
+
+      - name: Start stack
+        run: docker compose up -d
+        env:
+          # If your compose references an image name, map it:
+          TORRUS_IMAGE: torrus-api:ci
+
+      - name: Wait for health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:9090/healthz >/dev/null; then
+              echo "healthy"; exit 0
+            fi
+            sleep 1
+          done
+          echo "service not healthy"; docker compose logs --no-color; exit 1
+
+      - name: Exercise API
+        run: |
+          curl -fsS -X POST http://localhost:9090/v1/downloads \
+            -H "Content-Type: application/json" \
+            -d '{"source":"https://speed.hetzner.de/1MB.bin","targetPath":"/data"}' \
+            | tee /tmp/new.json
+
+          ID=$(jq -r '.id' </tmp/new.json)
+          test -n "$ID"
+
+          curl -fsS -X PATCH "http://localhost:9090/v1/downloads/$ID" \
+            -H "Content-Type: application/json" \
+            -d '{"desiredStatus":"Paused"}' >/dev/null
+
+          # list
+          curl -fsS http://localhost:9090/v1/downloads | jq .
+
+      - name: Logs on failure
+        if: failure()
+        run: docker compose logs --no-color
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+name: Lint
+on:
+  pull_request:
+    branches: [ dev, main ]
+  push:
+    branches: [ dev ]
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22.x' }
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.58
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --timeout=3m

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,47 @@
-.git
-.gitignore
-**/*.swp
-**/*.swo
-**/*.log
-logs/
-bin/
-dist/
-coverage.out
+# Go build artifacts
+/bin/
+/build/
+/dist/
+/out/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# Go coverage & test cache
+*.cover
+*.coverprofile
+*.test
+*.prof
+*.pprof
+*.log
+
+# IDE/editor files
 .vscode/
 .idea/
+*.swp
+*.swo
+*.iml
+.DS_Store
+
+# Logs
+logs/
+*.log
+
+# Environment & secrets
 .env
+.env.*
+!.env.example
+
+# Docker
+# base docker-compose.yaml is tracked, overrides are local only
+docker-compose.override.yaml
+docker-compose.override.*.yaml
+
+# GitHub Actions / CI temp
+.github/workflows/*.tmp
+
 Downloads/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,58 @@
+version: "3.9"
+
+services:
+  aria2:
+    image: p3terx/aria2-pro:latest
+    container_name: aria2
+    restart: unless-stopped
+    environment:
+      - RPC_SECRET=${ARIA2_SECRET:-changeme}
+      - RPC_PORT=6800
+      - LISTEN_PORT=51413
+      - DISK_CACHE=64M
+      - IPV6_MODE=false
+    ports:
+      - "6800:6800"     # JSON-RPC
+      - "51413:51413"   # BT/TCP
+      - "51413:51413/udp"
+    volumes:
+      - ./downloads:/downloads
+      - ./aria2-config:/config
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -z 127.0.0.1 6800"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
+  torrus:
+    # Build from your repo’s Dockerfile
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: torrus-api
+    restart: unless-stopped
+    depends_on:
+      aria2:
+        condition: service_healthy
+    environment:
+      # Logging
+      - LOG_FORMAT=${LOG_FORMAT:-text}                # text|json
+      - LOG_FILE_PATH=${LOG_FILE_PATH:-/var/log/torrus/torrus.log}
+      - LOG_MAX_SIZE=${LOG_MAX_SIZE:-5}              # MB
+      - LOG_MAX_BACKUPS=${LOG_MAX_BACKUPS:-3}
+      - LOG_MAX_AGE_DAYS=${LOG_MAX_AGE_DAYS:-7}
+
+      # aria2 client config
+      - ARIA2_RPC_URL=${ARIA2_RPC_URL:-http://aria2:6800/jsonrpc}
+      - ARIA2_SECRET=${ARIA2_SECRET:-changeme}
+      - ARIA2_TIMEOUT_MS=${ARIA2_TIMEOUT_MS:-5000}
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./logs:/var/log/torrus
+      - ./downloads:/downloads
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9090/healthz"]
+      interval: 5s
+      timeout: 2s
+      retries: 10


### PR DESCRIPTION
This sets up baseline CI checks and image builds while keeping publishing/push steps for later when deploying to k8s.
- Added lint job using golangci-lint for static analysis
- Introduced integration job running via docker-compose (brings up Torrus API + aria2 sidecar for end-to-end checks)
- Committed base docker-compose.yaml for local + CI use
- CI workflow now includes: lint → unit tests → integration (compose)