### PR TITLE
Fix composite literal in download service test

### DIFF
--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -133,7 +133,7 @@ func (m *mockDownloadRepo) ClearGID(ctx context.Context, id int) error {
 
 func TestDownloadService_List(t *testing.T) {
 	ctx := context.Background()
-	want := data.Downloads{{ID: 1}, {ID: 2}}
+	want := data.Downloads{&data.Download{ID: 1}, &data.Download{ID: 2}}
 	m := &mockDownloadRepo{
 		listFn: func(ctx context.Context) (data.Downloads, error) {
 			return want, nil


### PR DESCRIPTION
## Summary
- correct data.Downloads test initialization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b34538cb288329b6e3cc17e7378230