### PR TITLE
ci: remove curl healthcheck from compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,8 +51,6 @@ services:
     volumes:
       - ./logs:/var/log/torrus
       - ./downloads:/downloads
-    healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:9090/healthz"]
-      interval: 5s
-      timeout: 2s
-      retries: 10
+    # Distroless base image lacks shell utilities such as curl, so we
+    # can't run an in-container HTTP health probe. The integration
+    # workflow checks the API's health from the host instead.


### PR DESCRIPTION
## Summary
- avoid using curl in torrus healthcheck since distroless image lacks shell utilities

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b34635c9d083299d441d6c6a9d9fb5