### PR TITLE
docs: refresh OpenAPI spec for v1 routes and health check

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -5,20 +5,24 @@ info:
   description: |
     API for managing and monitoring downloads.
 
-    - All endpoints are served under `/v1`
+    - All API routes are served under `/v1` (except `/healthz`)
     - Request bodies are **strict JSON** (unknown fields rejected)
-    - POST body max size ~1 MiB (requests larger than this are rejected)
+    - Request body max size ~1 MiB
+    - `Content-Type` must be `application/json`
 
 servers:
-  - url: http://localhost:9090/v1
+  - url: http://localhost:9090
     description: Local development
+
+security:
+  - ApiTokenAuth: []
 
 tags:
   - name: Downloads
     description: Manage downloads
 
 paths:
-  /downloads:
+  /v1/downloads:
     get:
       tags: [Downloads]
       summary: List downloads
@@ -63,7 +67,7 @@ paths:
         "500":
           $ref: "#/components/responses/PlainError"
 
-  /downloads/{id}:
+  /v1/downloads/{id}:
     parameters:
       - name: id
         in: path
@@ -120,6 +124,20 @@ paths:
         "500":
           $ref: "#/components/responses/PlainError"
 
+  /healthz:
+    get:
+      summary: Health check
+      operationId: healthz
+      security: []
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
+
 components:
   responses:
     PlainError:
@@ -143,10 +161,11 @@ components:
         id:
           type: integer
           format: int32
+          readOnly: true
           example: 2
         source:
           type: string
-          description: Magnet URI
+          description: Download source link (e.g. magnet URI, HTTP URL)
           example: "magnet:?xt=urn:btih:1300da4907fcec1470bb3cd31563bb401cd33c14..."
         targetPath:
           type: string
@@ -154,11 +173,13 @@ components:
           example: "/movies/"
         status:
           $ref: "#/components/schemas/DownloadStatus"
+          readOnly: true
         desiredStatus:
           $ref: "#/components/schemas/DownloadStatus"
         createdAt:
           type: string
           format: date-time
+          readOnly: true
           example: "2025-08-22T12:34:56Z"
       required:
         - id
@@ -167,13 +188,13 @@ components:
         - status
         - createdAt
 
-    cleaDownloadCreate:
+    DownloadCreate:
       type: object
       additionalProperties: false
       properties:
         source:
           type: string
-          description: Magnet URI to start
+          description: Download source link (e.g. magnet URI, HTTP URL)
           example: "magnet:?xt=urn:btih:a216611be5b8d8c6306748d132774aa514977ee8..."
         targetPath:
           type: string
@@ -188,17 +209,20 @@ components:
       additionalProperties: false
       properties:
         desiredStatus:
+          type: string
           description: Desired state of the download
-          allOf:
-            - $ref: "#/components/schemas/DownloadStatus"
+          enum: ["Active", "Paused", "Cancelled"]
       required:
         - desiredStatus
 
     DownloadStatus:
       type: string
-      description: |
-        Current/desired download status.
-
-        **Note:** The API only accepts `Active`, `Paused`, `Cancelled` for PATCH.
+      description: Current/desired download status.
       enum: ["Queued", "Active", "Paused", "Complete", "Cancelled", "Failed"]
       example: "Queued"
+
+  securitySchemes:
+    ApiTokenAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API token


### PR DESCRIPTION
## Summary
- document /v1 routes and unversioned /healthz
- note strict JSON requests with content-type and size limits
- define download schema and allowed status transitions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b34dadc0e0832987bf8091722acd9d