### PR TITLE
feat(reconciler): introduce event-driven reconciler

### DIFF
--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
 	"github.com/tinoosan/torrus/internal/router"
+	"github.com/tinoosan/torrus/internal/service"
 )
 
 const testToken = "testtoken"
@@ -20,7 +23,10 @@ func setup(t *testing.T) http.Handler {
 	t.Helper()
 	t.Setenv("TORRUS_API_TOKEN", testToken)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return router.New(logger)
+	repo := repo.NewInMemoryDownloadRepo()
+	dlr := downloader.NewNoopDownloader()
+	svc := service.NewDownload(repo, dlr)
+	return router.New(logger, svc)
 }
 
 func authReq(r *http.Request) {

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -25,7 +26,9 @@ func newTestAdapter(t *testing.T, secret string, rt http.RoundTripper) *Adapter 
 		t.Fatalf("new client: %v", err)
 	}
 	c.HTTP().Transport = rt
-	return NewAdapter(c)
+	events := make(chan downloader.Event, 1)
+	rep := downloader.NewChanReporter(events)
+	return NewAdapter(c, rep)
 }
 
 func TestAdapterStart(t *testing.T) {

--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -1,0 +1,9 @@
+package downloader
+
+import "github.com/tinoosan/torrus/internal/data"
+
+type Event struct {
+	ID     int
+	GID    string
+	Status data.DownloadStatus
+}

--- a/internal/downloader/reporter.go
+++ b/internal/downloader/reporter.go
@@ -1,0 +1,20 @@
+package downloader
+
+// Reporter publishes downloader events.
+type Reporter interface {
+	Report(Event)
+}
+
+// ChanReporter writes events to a channel.
+type ChanReporter struct {
+	ch chan<- Event
+}
+
+func NewChanReporter(ch chan<- Event) *ChanReporter { return &ChanReporter{ch: ch} }
+
+func (r *ChanReporter) Report(e Event) {
+	if r == nil {
+		return
+	}
+	r.ch <- e
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -1,0 +1,70 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
+)
+
+// Reconciler consumes downloader events and updates repository state.
+type Reconciler struct {
+	repo   repo.DownloadWriter
+	events <-chan downloader.Event
+	log    *slog.Logger
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+func New(log *slog.Logger, repo repo.DownloadWriter, events <-chan downloader.Event) *Reconciler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Reconciler{repo: repo, events: events, log: log}
+}
+
+// Run starts the reconciliation loop.
+func (r *Reconciler) Run() {
+	r.stop = make(chan struct{})
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		for {
+			select {
+			case <-r.stop:
+				return
+			case e, ok := <-r.events:
+				if !ok {
+					return
+				}
+				r.handle(e)
+			}
+		}
+	}()
+}
+
+// Stop terminates the reconciliation loop.
+func (r *Reconciler) Stop() {
+	if r.stop != nil {
+		close(r.stop)
+		r.wg.Wait()
+	}
+}
+
+func (r *Reconciler) handle(e downloader.Event) {
+	if err := r.repo.SetStatus(context.Background(), e.ID, e.Status); err != nil {
+		r.log.Error("set status", "id", e.ID, "status", e.Status, "err", err)
+		return
+	}
+	switch e.Status {
+	case data.StatusCancelled, data.StatusComplete, data.StatusError:
+		if err := r.repo.ClearGID(context.Background(), e.ID); err != nil {
+			r.log.Error("clear gid", "id", e.ID, "err", err)
+		}
+	}
+	r.log.Info("reconciled event", "id", e.ID, "status", e.Status)
+}

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -1,24 +1,16 @@
 package router
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	v1 "github.com/tinoosan/torrus/api/v1"
-	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/auth"
-	"github.com/tinoosan/torrus/internal/downloader"
-	aria2dl "github.com/tinoosan/torrus/internal/downloader/aria2"
-	"github.com/tinoosan/torrus/internal/repo"
 	"github.com/tinoosan/torrus/internal/service"
 )
 
-func New(logger *slog.Logger) *mux.Router {
-
-	var dlr downloader.Downloader
+func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -27,23 +19,6 @@ func New(logger *slog.Logger) *mux.Router {
 			logger.Error("write healthz response", "err", err)
 		}
 	}).Methods("GET")
-
-	downloadRepo := repo.NewInMemoryDownloadRepo()
-
-	switch os.Getenv("TORRUS_CLIENT") {
-	case "aria2":
-		aria2Client, err := aria2.NewClientFromEnv()
-		if err != nil {
-			fmt.Println("Error:", err)
-			dlr = downloader.NewNoopDownloader()
-		} else {
-			dlr = aria2dl.NewAdapter(aria2Client)
-		}
-	default:
-		dlr = downloader.NewNoopDownloader()
-	}
-
-	downloadSvc := service.NewDownload(downloadRepo, dlr)
 
 	downloadHandler := v1.NewDownloadHandler(logger, downloadSvc)
 


### PR DESCRIPTION
## Summary
- add downloader events and reporters
- implement background reconciler updating download status
- publish start/pause/cancel events from aria2 adapter
- wire reconciler and event channel in main and router

## Testing
- `go test ./...`
- `curl -s -D - -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file","desiredStatus":"Active"}' http://localhost:9090/v1/downloads`
- `curl -s -H "Authorization: Bearer testtoken" http://localhost:9090/v1/downloads/1`
- `curl -s -X PATCH -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"desiredStatus":"Paused"}' http://localhost:9090/v1/downloads/1`
- `curl -s -X PATCH -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"desiredStatus":"Cancelled"}' http://localhost:9090/v1/downloads/1`


------
https://chatgpt.com/codex/tasks/task_e_68b3689dfcc483298f741f0aa8ac83e5