### PR TITLE
feat(reconciler): handle all downloader events

### DIFF
--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
 	"github.com/tinoosan/torrus/internal/router"
+	"github.com/tinoosan/torrus/internal/service"
 )
 
 const testToken = "testtoken"
@@ -20,7 +23,10 @@ func setup(t *testing.T) http.Handler {
 	t.Helper()
 	t.Setenv("TORRUS_API_TOKEN", testToken)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return router.New(logger)
+	repo := repo.NewInMemoryDownloadRepo()
+	dlr := downloader.NewNoopDownloader()
+	svc := service.NewDownload(repo, dlr)
+	return router.New(logger, svc)
 }
 
 func authReq(r *http.Request) {

--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -14,10 +14,13 @@ import (
 )
 
 type Adapter struct {
-	cl *aria2.Client
+	cl  *aria2.Client
+	rep downloader.Reporter
 }
 
-func NewAdapter(cl *aria2.Client) *Adapter { return &Adapter{cl: cl} }
+func NewAdapter(cl *aria2.Client, rep downloader.Reporter) *Adapter {
+	return &Adapter{cl: cl, rep: rep}
+}
 
 var _ downloader.Downloader = (*Adapter)(nil)
 
@@ -111,6 +114,9 @@ func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) 
 	if err := json.Unmarshal(res, &gid); err != nil {
 		return "", fmt.Errorf("parse addUri result: %w", err)
 	}
+	if a.rep != nil {
+		a.rep.Report(downloader.Event{ID: dl.ID, GID: gid, Type: downloader.EventStart})
+	}
 	return gid, nil
 }
 
@@ -118,6 +124,9 @@ func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) 
 func (a *Adapter) Pause(ctx context.Context, dl *data.Download) error {
 	params := append(a.tokenParam(), dl.GID)
 	_, err := a.call(ctx, "aria2.pause", params)
+	if err == nil && a.rep != nil {
+		a.rep.Report(downloader.Event{ID: dl.ID, GID: dl.GID, Type: downloader.EventPaused})
+	}
 	return err
 }
 
@@ -125,5 +134,31 @@ func (a *Adapter) Pause(ctx context.Context, dl *data.Download) error {
 func (a *Adapter) Cancel(ctx context.Context, dl *data.Download) error {
 	params := append(a.tokenParam(), dl.GID)
 	_, err := a.call(ctx, "aria2.remove", params)
+	if err == nil && a.rep != nil {
+		a.rep.Report(downloader.Event{ID: dl.ID, GID: dl.GID, Type: downloader.EventCancelled})
+	}
 	return err
+}
+
+// EmitComplete can be used by callers to signal that a download finished
+// successfully. Typically this would be triggered by an aria2 notification.
+func (a *Adapter) EmitComplete(id int, gid string) {
+	if a.rep != nil {
+		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventComplete})
+	}
+}
+
+// EmitFailed signals that a download has failed.
+func (a *Adapter) EmitFailed(id int, gid string) {
+	if a.rep != nil {
+		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventFailed})
+	}
+}
+
+// EmitProgress publishes a progress update for the given download. Callers are
+// responsible for providing whatever metrics they have available.
+func (a *Adapter) EmitProgress(id int, gid string, p downloader.Progress) {
+	if a.rep != nil {
+		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventProgress, Progress: &p})
+	}
 }

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -25,7 +26,9 @@ func newTestAdapter(t *testing.T, secret string, rt http.RoundTripper) *Adapter 
 		t.Fatalf("new client: %v", err)
 	}
 	c.HTTP().Transport = rt
-	return NewAdapter(c)
+	events := make(chan downloader.Event, 1)
+	rep := downloader.NewChanReporter(events)
+	return NewAdapter(c, rep)
 }
 
 func TestAdapterStart(t *testing.T) {

--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -1,0 +1,35 @@
+package downloader
+
+// Event represents a state change or progress update from a downloader.
+//
+// Type indicates what kind of event occurred. For terminal events
+// (e.g. Complete, Failed, Cancelled) the reconciler will update the
+// repository's Status and clear the GID where appropriate. Progress
+// events carry transient information about the download and do not
+// mutate repository state yet.
+type Event struct {
+	ID       int
+	GID      string
+	Type     EventType
+	Progress *Progress
+}
+
+// EventType defines the set of events that downloaders may emit.
+type EventType string
+
+const (
+	EventStart     EventType = "Start"
+	EventPaused    EventType = "Paused"
+	EventCancelled EventType = "Cancelled"
+	EventComplete  EventType = "Complete"
+	EventFailed    EventType = "Failed"
+	EventProgress  EventType = "Progress"
+)
+
+// Progress provides optional details about an in-progress download.
+// Values are left generic so downloaders can supply whatever metrics
+// they have available (e.g. bytes downloaded, total size).
+type Progress struct {
+	Completed int64
+	Total     int64
+}

--- a/internal/downloader/reporter.go
+++ b/internal/downloader/reporter.go
@@ -1,0 +1,20 @@
+package downloader
+
+// Reporter publishes downloader events.
+type Reporter interface {
+	Report(Event)
+}
+
+// ChanReporter writes events to a channel.
+type ChanReporter struct {
+	ch chan<- Event
+}
+
+func NewChanReporter(ch chan<- Event) *ChanReporter { return &ChanReporter{ch: ch} }
+
+func (r *ChanReporter) Report(e Event) {
+	if r == nil {
+		return
+	}
+	r.ch <- e
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -1,0 +1,95 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
+)
+
+// Reconciler consumes downloader events and updates repository state.
+type Reconciler struct {
+	repo   repo.DownloadWriter
+	events <-chan downloader.Event
+	log    *slog.Logger
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+func New(log *slog.Logger, repo repo.DownloadWriter, events <-chan downloader.Event) *Reconciler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Reconciler{repo: repo, events: events, log: log}
+}
+
+// Run starts the reconciliation loop.
+func (r *Reconciler) Run() {
+	r.stop = make(chan struct{})
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		for {
+			select {
+			case <-r.stop:
+				return
+			case e, ok := <-r.events:
+				if !ok {
+					return
+				}
+				r.handle(e)
+			}
+		}
+	}()
+}
+
+// Stop terminates the reconciliation loop.
+func (r *Reconciler) Stop() {
+	if r.stop != nil {
+		close(r.stop)
+		r.wg.Wait()
+	}
+}
+
+func (r *Reconciler) handle(e downloader.Event) {
+	var status data.DownloadStatus
+	switch e.Type {
+	case downloader.EventStart:
+		status = data.StatusActive
+	case downloader.EventPaused:
+		status = data.StatusPaused
+	case downloader.EventCancelled:
+		status = data.StatusCancelled
+	case downloader.EventComplete:
+		status = data.StatusComplete
+	case downloader.EventFailed:
+		status = data.StatusError
+	case downloader.EventProgress:
+		if e.Progress != nil {
+			r.log.Info("progress event", "id", e.ID, "completed", e.Progress.Completed, "total", e.Progress.Total)
+		} else {
+			r.log.Info("progress event", "id", e.ID)
+		}
+		return
+	default:
+		r.log.Warn("unknown event type", "id", e.ID, "type", e.Type)
+		return
+	}
+
+	if err := r.repo.SetStatus(context.Background(), e.ID, status); err != nil {
+		r.log.Error("set status", "id", e.ID, "status", status, "err", err)
+		return
+	}
+
+	switch e.Type {
+	case downloader.EventCancelled, downloader.EventComplete, downloader.EventFailed:
+		if err := r.repo.ClearGID(context.Background(), e.ID); err != nil {
+			r.log.Error("clear gid", "id", e.ID, "err", err)
+		}
+	}
+	r.log.Info("reconciled event", "id", e.ID, "type", e.Type)
+}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -1,0 +1,56 @@
+package reconciler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
+)
+
+// TestHandle ensures that terminal events update status and clear GID while
+// progress events do not mutate repository state.
+func TestHandle(t *testing.T) {
+	rpo := repo.NewInMemoryDownloadRepo()
+	// Seed repo with a download
+	dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive, GID: "g"}
+	if _, err := rpo.Add(context.Background(), dl); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)
+
+	r.handle(downloader.Event{ID: dl.ID, Type: downloader.EventProgress, Progress: &downloader.Progress{Completed: 10, Total: 100}})
+	got, _ := rpo.Get(context.Background(), dl.ID)
+	if got.Status != data.StatusActive {
+		t.Fatalf("progress mutated status: %v", got.Status)
+	}
+	if got.GID != "g" {
+		t.Fatalf("progress cleared gid: %q", got.GID)
+	}
+
+	r.handle(downloader.Event{ID: dl.ID, Type: downloader.EventComplete})
+	got, _ = rpo.Get(context.Background(), dl.ID)
+	if got.Status != data.StatusComplete {
+		t.Fatalf("complete status = %v", got.Status)
+	}
+	if got.GID != "" {
+		t.Fatalf("gid not cleared on complete: %q", got.GID)
+	}
+
+	// reset gid and test failure case
+	if err := rpo.SetGID(context.Background(), dl.ID, "g2"); err != nil {
+		t.Fatalf("set gid: %v", err)
+	}
+	r.handle(downloader.Event{ID: dl.ID, Type: downloader.EventFailed})
+	got, _ = rpo.Get(context.Background(), dl.ID)
+	if got.Status != data.StatusError {
+		t.Fatalf("failed status = %v", got.Status)
+	}
+	if got.GID != "" {
+		t.Fatalf("gid not cleared on failed: %q", got.GID)
+	}
+}

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -1,24 +1,16 @@
 package router
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	v1 "github.com/tinoosan/torrus/api/v1"
-	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/auth"
-	"github.com/tinoosan/torrus/internal/downloader"
-	aria2dl "github.com/tinoosan/torrus/internal/downloader/aria2"
-	"github.com/tinoosan/torrus/internal/repo"
 	"github.com/tinoosan/torrus/internal/service"
 )
 
-func New(logger *slog.Logger) *mux.Router {
-
-	var dlr downloader.Downloader
+func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
@@ -27,23 +19,6 @@ func New(logger *slog.Logger) *mux.Router {
 			logger.Error("write healthz response", "err", err)
 		}
 	}).Methods("GET")
-
-	downloadRepo := repo.NewInMemoryDownloadRepo()
-
-	switch os.Getenv("TORRUS_CLIENT") {
-	case "aria2":
-		aria2Client, err := aria2.NewClientFromEnv()
-		if err != nil {
-			fmt.Println("Error:", err)
-			dlr = downloader.NewNoopDownloader()
-		} else {
-			dlr = aria2dl.NewAdapter(aria2Client)
-		}
-	default:
-		dlr = downloader.NewNoopDownloader()
-	}
-
-	downloadSvc := service.NewDownload(downloadRepo, dlr)
 
 	downloadHandler := v1.NewDownloadHandler(logger, downloadSvc)
 


### PR DESCRIPTION
## Summary
- expand downloader events to include completion, failure and progress details
- reconcile event types to update status and clear GID for terminal states
- expose helper emissions for completion, failure and progress in aria2 adapter
- cover reconciler behavior with unit tests

## Testing
- `go test ./...`
- `curl -s -D - -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file","desiredStatus":"Active"}' http://localhost:9090/v1/downloads`
- `curl -s -H "Authorization: Bearer testtoken" http://localhost:9090/v1/downloads/1`
- `curl -s -X PATCH -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"desiredStatus":"Paused"}' http://localhost:9090/v1/downloads/1`
- `curl -s -X PATCH -H "Authorization: Bearer testtoken" -H "Content-Type: application/json" -d '{"desiredStatus":"Cancelled"}' http://localhost:9090/v1/downloads/1`


------
https://chatgpt.com/codex/tasks/task_e_68b3689dfcc483298f741f0aa8ac83e5