### PR TITLE
Guard terminal events against stale GIDs in reconciler

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -56,7 +56,10 @@ func (r *Reconciler) Stop() {
 }
 
 func (r *Reconciler) handle(e downloader.Event) {
-	var status data.DownloadStatus
+	var (
+		status        data.DownloadStatus
+		checkTerminal bool
+	)
 	switch e.Type {
 	case downloader.EventStart:
 		dl, err := r.repo.Get(context.Background(), e.ID)
@@ -73,10 +76,13 @@ func (r *Reconciler) handle(e downloader.Event) {
 		status = data.StatusPaused
 	case downloader.EventCancelled:
 		status = data.StatusCancelled
+		checkTerminal = true
 	case downloader.EventComplete:
 		status = data.StatusComplete
+		checkTerminal = true
 	case downloader.EventFailed:
 		status = data.StatusError
+		checkTerminal = true
 	case downloader.EventProgress:
 		if e.Progress != nil {
 			r.log.Info("progress event", "id", e.ID, "completed", e.Progress.Completed, "total", e.Progress.Total)
@@ -89,13 +95,24 @@ func (r *Reconciler) handle(e downloader.Event) {
 		return
 	}
 
+	if checkTerminal {
+		dl, err := r.repo.Get(context.Background(), e.ID)
+		if err != nil {
+			r.log.Error("get", "id", e.ID, "err", err)
+			return
+		}
+		if dl.GID != e.GID {
+			r.log.Info("ignoring stale terminal event", "id", e.ID, "eventGID", e.GID, "gid", dl.GID)
+			return
+		}
+	}
+
 	if err := r.repo.SetStatus(context.Background(), e.ID, status); err != nil {
 		r.log.Error("set status", "id", e.ID, "status", status, "err", err)
 		return
 	}
 
-	switch e.Type {
-	case downloader.EventCancelled, downloader.EventComplete, downloader.EventFailed:
+	if checkTerminal {
 		if err := r.repo.ClearGID(context.Background(), e.ID); err != nil {
 			r.log.Error("clear gid", "id", e.ID, "err", err)
 		}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -32,7 +32,7 @@ func TestHandle(t *testing.T) {
 		t.Fatalf("progress cleared gid: %q", got.GID)
 	}
 
-	r.handle(downloader.Event{ID: dl.ID, Type: downloader.EventComplete})
+	r.handle(downloader.Event{ID: dl.ID, GID: "g", Type: downloader.EventComplete})
 	got, _ = rpo.Get(context.Background(), dl.ID)
 	if got.Status != data.StatusComplete {
 		t.Fatalf("complete status = %v", got.Status)
@@ -45,7 +45,7 @@ func TestHandle(t *testing.T) {
 	if err := rpo.SetGID(context.Background(), dl.ID, "g2"); err != nil {
 		t.Fatalf("set gid: %v", err)
 	}
-	r.handle(downloader.Event{ID: dl.ID, Type: downloader.EventFailed})
+	r.handle(downloader.Event{ID: dl.ID, GID: "g2", Type: downloader.EventFailed})
 	got, _ = rpo.Get(context.Background(), dl.ID)
 	if got.Status != data.StatusError {
 		t.Fatalf("failed status = %v", got.Status)
@@ -79,5 +79,29 @@ func TestHandleStartDoesNotOverrideStatus(t *testing.T) {
 				t.Fatalf("start event overrode status: got %v want %v", got.Status, st)
 			}
 		})
+	}
+}
+
+// TestHandleIgnoresStaleTerminalEvent ensures that terminal events with a
+// mismatched GID do not mutate repository state.
+func TestHandleIgnoresStaleTerminalEvent(t *testing.T) {
+	rpo := repo.NewInMemoryDownloadRepo()
+	dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive, GID: "new"}
+	if _, err := rpo.Add(context.Background(), dl); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)
+
+	r.handle(downloader.Event{ID: dl.ID, GID: "old", Type: downloader.EventFailed})
+
+	got, err := rpo.Get(context.Background(), dl.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != data.StatusActive {
+		t.Fatalf("status changed on stale event: %v", got.Status)
+	}
+	if got.GID != "new" {
+		t.Fatalf("gid changed on stale event: %q", got.GID)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure terminal events match repo GID before status update
- cover stale terminal events in tests

## Testing
- `go test ./...`
- `go test ./internal/reconciler -run .`


------
https://chatgpt.com/codex/tasks/task_e_68b3757e48a88329bef77296650b0199