### PR TITLE
refactor: expand inline error handling

### DIFF
--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -59,7 +59,8 @@ func TestDownloadsLifecycle(t *testing.T) {
 		t.Fatalf("expected status 200 got %d", rr.Code)
 	}
 	var list []map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&list); err != nil {
+	err := json.NewDecoder(rr.Body).Decode(&list)
+	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(list) != 0 {
@@ -77,7 +78,8 @@ func TestDownloadsLifecycle(t *testing.T) {
 		t.Fatalf("expected status 201 got %d", rr.Code)
 	}
 	var created map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+	err = json.NewDecoder(rr.Body).Decode(&created)
+	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	id := int(created["id"].(float64))
@@ -91,7 +93,8 @@ func TestDownloadsLifecycle(t *testing.T) {
 		t.Fatalf("expected status 200 got %d", rr.Code)
 	}
 	list = nil
-	if err := json.NewDecoder(rr.Body).Decode(&list); err != nil {
+	err = json.NewDecoder(rr.Body).Decode(&list)
+	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(list) != 1 || int(list[0]["id"].(float64)) != id {

--- a/api/v1/middleware.go
+++ b/api/v1/middleware.go
@@ -26,7 +26,8 @@ func MiddlewareDownloadValidation(next http.Handler) http.Handler {
 		dl := &data.Download{}
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
-		if err := dec.Decode(dl); err != nil {
+		err := dec.Decode(dl)
+		if err != nil {
 			markErr(w, err)
 			http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
 			return
@@ -50,7 +51,8 @@ func MiddlewarePatchDesired(next http.Handler) http.Handler {
 		var body patchBody
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
-		if err := dec.Decode(&body); err != nil {
+		err := dec.Decode(&body)
+		if err != nil {
 			markErr(w, err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,8 @@ func main() {
 		return
 	}
 	defer func() {
-		if err := rotator.Close(); err != nil {
+		err := rotator.Close()
+		if err != nil {
 			fmt.Printf("close log file: %v", err)
 		}
 	}()
@@ -135,7 +136,8 @@ func main() {
 			"rotate_age_days", logOptions.Age,
 		)
 		logger.Info("Starting Torrus API on", "port", server.Addr)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
 			logger.Error("Server error:", "err", err)
 		}
 	}()
@@ -148,7 +150,8 @@ func main() {
 	timeout := 30 * time.Second
 	timeoutContext, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	if err := server.Shutdown(timeoutContext); err != nil {
+	err = server.Shutdown(timeoutContext)
+	if err != nil {
 		logger.Error("Graceful shutdown failed", "err", err)
 	}
 	rec.Stop()

--- a/internal/aria2/client.go
+++ b/internal/aria2/client.go
@@ -22,7 +22,8 @@ type Client struct {
 func NewClientFromEnv() (*Client, error) {
 	ms := 3000
 	if v := os.Getenv("ARIA2_TIMEOUT_MS"); v != "" {
-		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+		parsed, err := strconv.Atoi(v)
+		if err == nil && parsed > 0 {
 			ms = parsed
 		}
 	}

--- a/internal/aria2/client_test.go
+++ b/internal/aria2/client_test.go
@@ -59,7 +59,8 @@ func TestNewClientFromEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// ensure clean environment and set using t.Setenv
 			for _, k := range []string{"ARIA2_RPC_URL", "ARIA2_SECRET", "ARIA2_TIMEOUT_MS"} {
-				if err := os.Unsetenv(k); err != nil {
+				err := os.Unsetenv(k)
+				if err != nil {
 					t.Fatalf("unset %s: %v", k, err)
 				}
 			}

--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -78,7 +78,8 @@ func (a *Adapter) call(ctx context.Context, method string, params []interface{})
 	b, _ := io.ReadAll(resp.Body)
 
 	var rr rpcResp
-	if err := json.Unmarshal(b, &rr); err != nil {
+	err = json.Unmarshal(b, &rr)
+	if err != nil {
 		return nil, fmt.Errorf("aria2 rpc decode: %w (%s)", err, string(b))
 	}
 	if rr.Error != nil {
@@ -114,7 +115,8 @@ func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) 
 	}
 	// result is GID string
 	var gid string
-	if err := json.Unmarshal(res, &gid); err != nil {
+	err = json.Unmarshal(res, &gid)
+	if err != nil {
 		return "", fmt.Errorf("parse addUri result: %w", err)
 	}
 	if a.rep != nil {

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -37,7 +37,8 @@ func TestAdapterStart(t *testing.T) {
 		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			b, _ := io.ReadAll(r.Body)
 			var req rpcReq
-			if err := json.Unmarshal(b, &req); err != nil {
+			err := json.Unmarshal(b, &req)
+			if err != nil {
 				t.Fatalf("decode request: %v", err)
 			}
 			if req.Method != "aria2.addUri" {
@@ -77,7 +78,8 @@ func TestAdapterStart(t *testing.T) {
 		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			b, _ := io.ReadAll(r.Body)
 			var req rpcReq
-			if err := json.Unmarshal(b, &req); err != nil {
+			err := json.Unmarshal(b, &req)
+			if err != nil {
 				t.Fatalf("decode request: %v", err)
 			}
 			if req.Method != "aria2.addUri" {
@@ -123,7 +125,8 @@ func TestAdapterPauseCancel(t *testing.T) {
 			rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 				b, _ := io.ReadAll(r.Body)
 				var req rpcReq
-				if err := json.Unmarshal(b, &req); err != nil {
+				err := json.Unmarshal(b, &req)
+				if err != nil {
 					t.Fatalf("decode request: %v", err)
 				}
 				if req.Method != m.rpcMethod {
@@ -146,7 +149,8 @@ func TestAdapterPauseCancel(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
 			})
 			a := newTestAdapter(t, "secret", rt)
-			if err := m.call(context.Background(), a, dl); err != nil {
+			err := m.call(context.Background(), a, dl)
+			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
@@ -159,7 +163,8 @@ func TestAdapterPauseCancel(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
 			})
 			a := newTestAdapter(t, "", rt)
-			if err := m.call(context.Background(), a, dl); err == nil {
+			err := m.call(context.Background(), a, dl)
+			if err == nil {
 				t.Fatalf("expected error")
 			}
 		})

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -101,13 +101,14 @@ func (r *Reconciler) handle(e downloader.Event) {
 		return
 	}
 
-	if _, err := r.repo.Update(context.Background(), e.ID, func(dl *data.Download) error {
+	_, err := r.repo.Update(context.Background(), e.ID, func(dl *data.Download) error {
 		dl.Status = status
 		if checkTerminal {
 			dl.GID = ""
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		r.log.Error("update", "id", e.ID, "status", status, "err", err)
 		return
 	}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -17,7 +17,8 @@ func TestHandle(t *testing.T) {
 	rpo := repo.NewInMemoryDownloadRepo()
 	// Seed repo with a download
 	dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive, GID: "g"}
-	if _, err := rpo.Add(context.Background(), dl); err != nil {
+	_, err := rpo.Add(context.Background(), dl)
+	if err != nil {
 		t.Fatalf("add: %v", err)
 	}
 
@@ -42,7 +43,8 @@ func TestHandle(t *testing.T) {
 	}
 
 	// reset gid and test failure case
-	if _, err := rpo.Update(context.Background(), dl.ID, func(d *data.Download) error { d.GID = "g2"; return nil }); err != nil {
+	_, err = rpo.Update(context.Background(), dl.ID, func(d *data.Download) error { d.GID = "g2"; return nil })
+	if err != nil {
 		t.Fatalf("set gid: %v", err)
 	}
 	r.handle(downloader.Event{ID: dl.ID, GID: "g2", Type: downloader.EventFailed})
@@ -64,7 +66,8 @@ func TestHandleStartDoesNotOverrideStatus(t *testing.T) {
 		t.Run(string(st), func(t *testing.T) {
 			rpo := repo.NewInMemoryDownloadRepo()
 			dl := &data.Download{Source: "s", TargetPath: "t", Status: st, DesiredStatus: st}
-			if _, err := rpo.Add(context.Background(), dl); err != nil {
+			_, err := rpo.Add(context.Background(), dl)
+			if err != nil {
 				t.Fatalf("add: %v", err)
 			}
 			r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)
@@ -89,7 +92,8 @@ func TestHandleIgnoresStaleTerminalEvents(t *testing.T) {
 	t.Run("mismatched gid", func(t *testing.T) {
 		rpo := repo.NewInMemoryDownloadRepo()
 		dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive, GID: "g"}
-		if _, err := rpo.Add(context.Background(), dl); err != nil {
+		_, err := rpo.Add(context.Background(), dl)
+		if err != nil {
 			t.Fatalf("add: %v", err)
 		}
 		r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)
@@ -108,7 +112,8 @@ func TestHandleIgnoresStaleTerminalEvents(t *testing.T) {
 	t.Run("missing repo gid", func(t *testing.T) {
 		rpo := repo.NewInMemoryDownloadRepo()
 		dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive}
-		if _, err := rpo.Add(context.Background(), dl); err != nil {
+		_, err := rpo.Add(context.Background(), dl)
+		if err != nil {
 			t.Fatalf("add: %v", err)
 		}
 		r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)

--- a/internal/repo/inmem.go
+++ b/internal/repo/inmem.go
@@ -65,7 +65,8 @@ func (r *InMemoryDownloadRepo) Update(ctx context.Context, id int, mutate func(*
 	}
 
 	if mutate != nil {
-		if err := mutate(dl); err != nil {
+		err = mutate(dl)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/internal/repo/inmem_test.go
+++ b/internal/repo/inmem_test.go
@@ -48,7 +48,8 @@ func TestInMemoryDownloadRepo_AddListGet(t *testing.T) {
 		t.Fatalf("Get mismatch")
 	}
 
-	if _, err := r.Get(ctx, 999); !errors.Is(err, data.ErrNotFound) {
+	_, err = r.Get(ctx, 999)
+	if !errors.Is(err, data.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound")
 	}
 }
@@ -176,10 +177,12 @@ func TestInMemoryDownloadRepo_Concurrency(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < n; i++ {
-			if _, err := repo.List(ctx); err != nil {
+			_, err := repo.List(ctx)
+			if err != nil {
 				t.Errorf("List error: %v", err)
 			}
-			if _, err := repo.Get(ctx, i); err != nil && !errors.Is(err, data.ErrNotFound) {
+			_, err = repo.Get(ctx, i)
+			if err != nil && !errors.Is(err, data.ErrNotFound) {
 				t.Errorf("Get error: %v", err)
 			}
 		}
@@ -190,7 +193,8 @@ func TestInMemoryDownloadRepo_Concurrency(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			if _, err := repo.Add(ctx, &data.Download{Source: fmt.Sprintf("s%d", i), TargetPath: "t"}); err != nil {
+			_, err := repo.Add(ctx, &data.Download{Source: fmt.Sprintf("s%d", i), TargetPath: "t"})
+			if err != nil {
 				t.Errorf("Add error: %v", err)
 			}
 		}(i)

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -16,7 +16,8 @@ func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		if _, err := w.Write([]byte("ok")); err != nil {
+		_, err := w.Write([]byte("ok"))
+		if err != nil {
 			logger.Error("write healthz response", "err", err)
 		}
 	}).Methods("GET")

--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -117,7 +117,8 @@ func TestUpdateDesiredStatus(t *testing.T) {
 	t.Run("invalid status", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
 		svc := NewDownload(r, &stubDownloader{})
-		if _, err := svc.UpdateDesiredStatus(ctx, 1, data.StatusQueued); !errors.Is(err, data.ErrBadStatus) {
+		_, err := svc.UpdateDesiredStatus(ctx, 1, data.StatusQueued)
+		if !errors.Is(err, data.ErrBadStatus) {
 			t.Fatalf("expected ErrBadStatus, got %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary
- expand inline `if err :=` checks to explicit err handling for readability

## Testing
- `go vet ./...`
- `golangci-lint run`
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b42990cbe88329baeb1513365503d5