### PR TITLE
propagate request context

### DIFF
--- a/internal/service/download.go
+++ b/internal/service/download.go
@@ -85,28 +85,28 @@ func (ds *download) Add(ctx context.Context, d *data.Download) (*data.Download, 
 	}
 
 	if saved.Status == data.StatusActive {
-		go func(d *data.Download) {
-			gid, derr := ds.dlr.Start(context.Background(), d)
+		go func(ctx context.Context, d *data.Download) {
+			gid, derr := ds.dlr.Start(ctx, d)
 			if derr != nil {
-				_, _ = ds.repo.Update(context.Background(), d.ID, func(dl *data.Download) error {
+				_, _ = ds.repo.Update(ctx, d.ID, func(dl *data.Download) error {
 					dl.Status = data.StatusError
 					return nil
 				})
 				return
 			}
-			_, err := ds.repo.Update(context.Background(), d.ID, func(dl *data.Download) error {
+			_, err := ds.repo.Update(ctx, d.ID, func(dl *data.Download) error {
 				dl.GID = gid
 				return nil
 			})
 			if err != nil {
-				_, _ = ds.repo.Update(context.Background(), d.ID, func(dl *data.Download) error {
+				_, _ = ds.repo.Update(ctx, d.ID, func(dl *data.Download) error {
 					dl.Status = data.StatusError
 					return nil
 				})
 				return
 			}
 			d.GID = gid
-		}(saved)
+		}(ctx, saved)
 	}
 	return saved, nil
 }


### PR DESCRIPTION
## Summary
- replace background contexts in service with request context
- attach cancellable context to reconciler and repo calls

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b42bccf23c8329be7f5b7567f60973