### PR TITLE
feat(aria2): wire aria2 notifications into Torrus events

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -106,7 +106,9 @@ func main() {
 			fmt.Println("Error:", err)
 			dlr = downloader.NewNoopDownloader()
 		} else {
-			dlr = aria2dl.NewAdapter(aria2Client, rep)
+			a := aria2dl.NewAdapter(aria2Client, rep)
+			go a.Run(context.Background())
+			dlr = a
 		}
 	default:
 		dlr = downloader.NewNoopDownloader()

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.24.4
 require (
 	github.com/gorilla/mux v1.8.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+	nhooyr.io/websocket v1.8.9
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+nhooyr.io/websocket v1.8.9 h1:+U/9DCNIH1XnzrWKs7yZp4jO0e/m6mUEh2kRPKRQYeg=
+nhooyr.io/websocket v1.8.9/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/aria2/notify.go
+++ b/internal/aria2/notify.go
@@ -1,0 +1,60 @@
+package aria2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"nhooyr.io/websocket"
+)
+
+// Notification represents an async event pushed by aria2.
+type Notification struct {
+	Method string              `json:"method"`
+	Params []NotificationEvent `json:"params"`
+}
+
+// NotificationEvent contains details for an aria2 notification.
+type NotificationEvent struct {
+	GID string `json:"gid"`
+}
+
+// Notifications connects to the aria2 WebSocket endpoint and streams
+// async notifications. The returned channel is closed when the connection
+// terminates or the context is cancelled.
+func (c *Client) Notifications(ctx context.Context) (<-chan Notification, error) {
+	wsURL := *c.baseURL
+	switch wsURL.Scheme {
+	case "http":
+		wsURL.Scheme = "ws"
+	case "https":
+		wsURL.Scheme = "wss"
+	default:
+		return nil, fmt.Errorf("unsupported scheme: %s", wsURL.Scheme)
+	}
+	// nhooyr websocket requires no fragments; path remains same
+	conn, _, err := websocket.Dial(ctx, wsURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan Notification, 8)
+	go func() {
+		defer close(ch)
+		defer conn.Close(websocket.StatusNormalClosure, "done")
+		for {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			// aria2 may send newline-delimited JSON; trim
+			data = []byte(strings.TrimSpace(string(data)))
+			var n Notification
+			if err := json.Unmarshal(data, &n); err != nil {
+				continue
+			}
+			ch <- n
+		}
+	}()
+	return ch, nil
+}


### PR DESCRIPTION
## Summary
- connect to aria2's WebSocket notifications
- translate aria2 events into Torrus downloader events
- start notification listener in cmd startup

## Testing
- `go test ./...`