### PR TITLE
feat(aria2): emit progress events via tellStatus

### DIFF
--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -30,6 +30,9 @@ const (
 // Values are left generic so downloaders can supply whatever metrics
 // they have available (e.g. bytes downloaded, total size).
 type Progress struct {
-	Completed int64
-	Total     int64
+    Completed int64
+    Total     int64
+    // Speed is the current download speed in bytes/sec, if available.
+    // A value of 0 indicates it was not provided by the adapter.
+    Speed     int64
 }


### PR DESCRIPTION
- Extend downloader.Progress with Speed (bytes/sec).
- Add aria2.tellStatus helper to parse completedLength, totalLength, and downloadSpeed.
- Update adapter to emit EventProgress on download start/pause notifications.
- Maintain gid→id map, thread context into notification handling.
- Add unit tests for progress emission and updated handleNotification signature.