### PR TITLE
feat(download): add read-only Name field populated by downloader metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Fields returned by the downloads API:
 | `gid`           | string | Backend identifier, may be `null` (read-only)                               |
 | `source`        | string | Download source link (magnet URI, HTTP URL, etc.)                           |
 | `targetPath`    | string | Destination path for the download                                           |
+| `name`          | string | Human-friendly display name from the downloader (read-only, optional)       |
 | `status`        | string | Current status. One of `Queued`, `Active`, `Paused`, `Complete`, `Cancelled`, `Failed` (read-only) |
 | `desiredStatus` | string | Desired status. Same enum as `status`                                       |
 | `createdAt`     | string | RFC3339 timestamp when the download was created (read-only)                 |

--- a/api/v1/errors.go
+++ b/api/v1/errors.go
@@ -3,12 +3,12 @@ package v1
 import "errors"
 
 var (
-	ErrDownloadCtx   = errors.New("download missing in context")
-	ErrDesiredStatus = errors.New("desired status missing in context")
-	ErrDesiredStatusJSON = errors.New("desired status is required")
-	ErrTargetPath = errors.New("targetPath is required")
-	ErrContentType = errors.New("Content-Type must be application/json")
-	ErrMagnetURI = errors.New("invalid magnet link")
+    ErrDownloadCtx   = errors.New("download missing in context")
+    ErrDesiredStatus = errors.New("desired status missing in context")
+    ErrDesiredStatusJSON = errors.New("desired status is required")
+    ErrTargetPath = errors.New("targetPath is required")
+    ErrContentType = errors.New("Content-Type must be application/json")
+    ErrMagnetURI = errors.New("invalid magnet link")
+    ErrReadOnlyName = errors.New("name is read-only and cannot be set")
 
 )
-

--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -121,19 +121,20 @@ func TestDownloadsLifecycle(t *testing.T) {
 }
 
 func TestPostDownloadValidation(t *testing.T) {
-	h := setup(t)
+    h := setup(t)
 
-	tests := []struct {
-		name        string
-		contentType string
-		body        string
-		want        int
-	}{
-		{"wrong content-type", "text/plain", "{}", http.StatusUnsupportedMediaType},
-		{"unknown field", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","extra":1}`, http.StatusBadRequest},
-		{"missing target", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef"}`, http.StatusBadRequest},
-		{"body too large", "application/json", `{"source":"magnet:?xt=urn:btih:` + strings.Repeat("a", 1<<20) + `","targetPath":"/tmp"}`, http.StatusBadRequest},
-	}
+    tests := []struct {
+        name        string
+        contentType string
+        body        string
+        want        int
+    }{
+        {"wrong content-type", "text/plain", "{}", http.StatusUnsupportedMediaType},
+        {"unknown field", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","extra":1}`, http.StatusBadRequest},
+        {"missing target", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef"}`, http.StatusBadRequest},
+        {"body too large", "application/json", `{"source":"magnet:?xt=urn:btih:` + strings.Repeat("a", 1<<20) + `","targetPath":"/tmp"}`, http.StatusBadRequest},
+        {"name provided (read-only)", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","name":"hack"}`, http.StatusBadRequest},
+    }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/v1/middleware.go
+++ b/api/v1/middleware.go
@@ -33,6 +33,13 @@ func MiddlewareDownloadValidation(next http.Handler) http.Handler {
 			return
 		}
 
+		// Enforce read-only fields: reject if client sets name.
+		if dl.Name != "" {
+			markErr(w, ErrReadOnlyName)
+			http.Error(w, ErrReadOnlyName.Error(), http.StatusBadRequest)
+			return
+		}
+
 		ctx := context.WithValue(r.Context(), ctxKeyDownload{}, dl)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/index.yaml
+++ b/index.yaml
@@ -177,6 +177,11 @@ components:
           type: string
           description: Absolute or configured destination path
           example: "/movies/"
+        name:
+          type: string
+          description: Human-friendly display name provided by downloader
+          readOnly: true
+          example: "Some.Movie.2024.1080p.mkv"
         status:
           $ref: "#/components/schemas/DownloadStatus"
           readOnly: true

--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -11,13 +11,15 @@ import (
 // Download represents a single file transfer managed by Torrus.
 // It tracks the source URI, destination path and current state.
 type Download struct {
-	ID            int            `json:"id"`
-	GID           string         `json:"gid"`
-	Source        string         `json:"source"`
-	TargetPath    string         `json:"targetPath"`
-	Status        DownloadStatus `json:"status"`
-	DesiredStatus DownloadStatus `json:"desiredStatus,omitempty"`
-	CreatedAt     time.Time      `json:"createdAt"`
+    ID            int            `json:"id"`
+    GID           string         `json:"gid"`
+    Source        string         `json:"source"`
+    TargetPath    string         `json:"targetPath"`
+    // Name is a read-only field populated by the downloader via events.
+    Name          string         `json:"name,omitempty"`
+    Status        DownloadStatus `json:"status"`
+    DesiredStatus DownloadStatus `json:"desiredStatus,omitempty"`
+    CreatedAt     time.Time      `json:"createdAt"`
 }
 
 // Possible DownloadStatus values.

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -31,47 +31,61 @@ func newTestAdapter(t *testing.T, secret string, rt http.RoundTripper) *Adapter 
 	return NewAdapter(c, rep)
 }
 
+func newTestAdapterWithEvents(t *testing.T, secret string, rt http.RoundTripper) (*Adapter, chan downloader.Event) {
+    t.Helper()
+    t.Setenv("ARIA2_RPC_URL", "http://example.com/jsonrpc")
+    t.Setenv("ARIA2_SECRET", secret)
+    c, err := aria2.NewClientFromEnv()
+    if err != nil {
+        t.Fatalf("new client: %v", err)
+    }
+    c.HTTP().Transport = rt
+    events := make(chan downloader.Event, 4)
+    rep := downloader.NewChanReporter(events)
+    return NewAdapter(c, rep), events
+}
+
 func TestAdapterStart(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		dl := &data.Download{Source: "http://foo/bar", TargetPath: "/tmp"}
-		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			b, _ := io.ReadAll(r.Body)
-			var req rpcReq
-			err := json.Unmarshal(b, &req)
-			if err != nil {
-				t.Fatalf("decode request: %v", err)
-			}
-			if req.Method != "aria2.addUri" {
-				t.Fatalf("method = %s", req.Method)
-			}
-			if req.ID != "torrus" {
-				t.Fatalf("id = %s", req.ID)
-			}
-			if len(req.Params) != 3 {
-				t.Fatalf("params len = %d", len(req.Params))
-			}
-			if tok, _ := req.Params[0].(string); tok != "token:secret" {
-				t.Fatalf("token param = %v", req.Params[0])
-			}
-			if uris, ok := req.Params[1].([]interface{}); !ok || len(uris) != 1 || uris[0] != dl.Source {
-				t.Fatalf("uris param = %#v", req.Params[1])
-			}
-			if opts, ok := req.Params[2].(map[string]interface{}); !ok || opts["dir"] != dl.TargetPath {
-				t.Fatalf("opts = %#v", req.Params[2])
-			}
-			resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"gid123"`)}
-			rb, _ := json.Marshal(resp)
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		})
-		a := newTestAdapter(t, "secret", rt)
-		gid, err := a.Start(context.Background(), dl)
-		if err != nil {
-			t.Fatalf("Start error: %v", err)
-		}
-		if gid != "gid123" {
-			t.Fatalf("gid = %s", gid)
-		}
-	})
+    t.Run("success", func(t *testing.T) {
+        dl := &data.Download{ID: 1, Source: "http://example.com/files/movie.mkv", TargetPath: "/tmp"}
+        first := true
+        rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+            b, _ := io.ReadAll(r.Body)
+            var req rpcReq
+            if err := json.Unmarshal(b, &req); err != nil {
+                t.Fatalf("decode request: %v", err)
+            }
+            if first {
+                first = false
+                if req.Method != "aria2.addUri" {
+                    t.Fatalf("method = %s", req.Method)
+                }
+                resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"gid123"`)}
+                rb, _ := json.Marshal(resp)
+                return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+            }
+            if req.Method != "aria2.tellStatus" {
+                t.Fatalf("expected tellStatus, got %s", req.Method)
+            }
+            // Return files path to extract name
+            result := map[string]any{
+                "files": []map[string]any{{"path": "/downloads/movie.mkv"}},
+            }
+            rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+            return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+        })
+        a, events := newTestAdapterWithEvents(t, "secret", rt)
+        gid, err := a.Start(context.Background(), dl)
+        if err != nil { t.Fatalf("Start error: %v", err) }
+        if gid != "gid123" { t.Fatalf("gid = %s", gid) }
+        // Expect Start then Meta
+        ev1 := <-events
+        if ev1.Type != downloader.EventStart { t.Fatalf("first event = %v", ev1.Type) }
+        ev2 := <-events
+        if ev2.Type != downloader.EventMeta || ev2.Meta == nil || ev2.Meta.Name == nil || *ev2.Meta.Name != "movie.mkv" {
+            t.Fatalf("unexpected meta event: %#v", ev2)
+        }
+    })
 
 	t.Run("rpc error", func(t *testing.T) {
 		dl := &data.Download{Source: "http://foo/bar"}
@@ -109,6 +123,37 @@ func TestAdapterStart(t *testing.T) {
 	})
 }
 
+func must[T any](v T, err error) T { if err != nil { panic(err) }; return v }
+
+func TestAdapterResumeEmitsMeta(t *testing.T) {
+    dl := &data.Download{ID: 1, Source: "magnet:?xt=urn:btih:abc&dn=Cool.Name.2024", GID: "gid-9"}
+    first := true
+    rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+        b, _ := io.ReadAll(r.Body)
+        var req rpcReq
+        if err := json.Unmarshal(b, &req); err != nil { t.Fatalf("decode: %v", err) }
+        if first {
+            first = false
+            if req.Method != "aria2.unpause" { t.Fatalf("method = %s", req.Method) }
+            rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+            return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+        }
+        if req.Method != "aria2.tellStatus" { t.Fatalf("expected tellStatus, got %s", req.Method) }
+        // No metadata; adapter should fallback to magnet dn
+        result := map[string]any{}
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    })
+    a, events := newTestAdapterWithEvents(t, "secret", rt)
+    if err := a.Resume(context.Background(), dl); err != nil { t.Fatalf("resume: %v", err) }
+    // Expect Meta with fallback name
+    ev := <-events
+    if ev.Type == downloader.EventStart { ev = <-events }
+    if ev.Type != downloader.EventMeta || ev.Meta == nil || ev.Meta.Name == nil || *ev.Meta.Name != "Cool.Name.2024" {
+        t.Fatalf("unexpected event: %#v", ev)
+    }
+}
+
 func TestAdapterPauseCancel(t *testing.T) {
     methods := []struct {
         name      string
@@ -120,41 +165,56 @@ func TestAdapterPauseCancel(t *testing.T) {
         {"Cancel", "aria2.remove", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Cancel(ctx, d) }},
     }
 
-	for _, m := range methods {
-		t.Run(m.name+" success", func(t *testing.T) {
-			dl := &data.Download{GID: "gid-1"}
-			rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
-				b, _ := io.ReadAll(r.Body)
-				var req rpcReq
-				err := json.Unmarshal(b, &req)
-				if err != nil {
-					t.Fatalf("decode request: %v", err)
-				}
-				if req.Method != m.rpcMethod {
-					t.Fatalf("method = %s", req.Method)
-				}
-				if req.ID != "torrus" {
-					t.Fatalf("id = %s", req.ID)
-				}
-				if len(req.Params) != 2 {
-					t.Fatalf("params len = %d", len(req.Params))
-				}
-				if tok, _ := req.Params[0].(string); tok != "token:secret" {
-					t.Fatalf("token param = %v", req.Params[0])
-				}
-				if gid, _ := req.Params[1].(string); gid != dl.GID {
-					t.Fatalf("gid param = %v", req.Params[1])
-				}
-				resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)}
-				rb, _ := json.Marshal(resp)
-				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-			})
-			a := newTestAdapter(t, "secret", rt)
-			err := m.call(context.Background(), a, dl)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-		})
+    for _, m := range methods {
+        t.Run(m.name+" success", func(t *testing.T) {
+            dl := &data.Download{GID: "gid-1"}
+            first := true
+            rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+                b, _ := io.ReadAll(r.Body)
+                var req rpcReq
+                err := json.Unmarshal(b, &req)
+                if err != nil {
+                    t.Fatalf("decode request: %v", err)
+                }
+                if first {
+                    first = false
+                    if req.Method != m.rpcMethod {
+                        t.Fatalf("method = %s", req.Method)
+                    }
+                } else {
+                    // For Resume, a subsequent tellStatus is expected; others should not hit here
+                    if m.name != "Resume" || req.Method != "aria2.tellStatus" {
+                        t.Fatalf("unexpected extra call: %s", req.Method)
+                    }
+                }
+                if req.ID != "torrus" {
+                    t.Fatalf("id = %s", req.ID)
+                }
+                // Return success for first call; for tellStatus provide empty result
+                if req.Method == m.rpcMethod {
+                    if len(req.Params) != 2 {
+                        t.Fatalf("params len = %d", len(req.Params))
+                    }
+                    if tok, _ := req.Params[0].(string); tok != "token:secret" {
+                        t.Fatalf("token param = %v", req.Params[0])
+                    }
+                    if gid, _ := req.Params[1].(string); gid != dl.GID {
+                        t.Fatalf("gid param = %v", req.Params[1])
+                    }
+                    resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)}
+                    rb, _ := json.Marshal(resp)
+                    return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+                }
+                // tellStatus response (empty)
+                rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`{}`)})
+                return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+            })
+            a := newTestAdapter(t, "secret", rt)
+            err := m.call(context.Background(), a, dl)
+            if err != nil {
+                t.Fatalf("unexpected error: %v", err)
+            }
+        })
 
 		t.Run(m.name+" error", func(t *testing.T) {
 			dl := &data.Download{GID: "gid-1"}

--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -8,22 +8,24 @@ package downloader
 // events carry transient information about the download and do not
 // mutate repository state yet.
 type Event struct {
-	ID       int
-	GID      string
-	Type     EventType
-	Progress *Progress
+    ID       int
+    GID      string
+    Type     EventType
+    Progress *Progress
+    Meta     *Meta
 }
 
 // EventType defines the set of events that downloaders may emit.
 type EventType string
 
 const (
-	EventStart     EventType = "Start"
-	EventPaused    EventType = "Paused"
-	EventCancelled EventType = "Cancelled"
-	EventComplete  EventType = "Complete"
-	EventFailed    EventType = "Failed"
-	EventProgress  EventType = "Progress"
+    EventStart     EventType = "Start"
+    EventPaused    EventType = "Paused"
+    EventCancelled EventType = "Cancelled"
+    EventComplete  EventType = "Complete"
+    EventFailed    EventType = "Failed"
+    EventProgress  EventType = "Progress"
+    EventMeta      EventType = "Meta"
 )
 
 // Progress provides optional details about an in-progress download.
@@ -35,4 +37,10 @@ type Progress struct {
     // Speed is the current download speed in bytes/sec, if available.
     // A value of 0 indicates it was not provided by the adapter.
     Speed     int64
+}
+
+// Meta carries optional metadata about a download that should be persisted
+// by the reconciler, such as the resolved resource name.
+type Meta struct {
+    Name *string
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -91,6 +91,22 @@ func (r *Reconciler) handle(e downloader.Event) {
 	case downloader.EventFailed:
 		status = data.StatusError
 		checkTerminal = true
+    case downloader.EventMeta:
+        if e.Meta == nil {
+            return
+        }
+        if e.Meta.Name != nil {
+            _, err := r.repo.Update(r.ctx, e.ID, func(dl *data.Download) error {
+                dl.Name = *e.Meta.Name
+                return nil
+            })
+            if err != nil {
+                r.log.Error("update meta", "id", e.ID, "err", err)
+            } else {
+                r.log.Info("updated meta", "id", e.ID, "name", *e.Meta.Name)
+            }
+        }
+        return
     case downloader.EventProgress:
         if e.Progress != nil {
             r.log.Info("progress event", "id", e.ID, "completed", e.Progress.Completed, "total", e.Progress.Total, "speed", e.Progress.Speed)

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -57,6 +57,18 @@ func TestHandle(t *testing.T) {
 	}
 }
 
+func TestHandleMetaUpdatesName(t *testing.T) {
+    rpo := repo.NewInMemoryDownloadRepo()
+    dl := &data.Download{Source: "s", TargetPath: "t", Status: data.StatusActive}
+    _, err := rpo.Add(context.Background(), dl)
+    if err != nil { t.Fatalf("add: %v", err) }
+    r := New(slog.New(slog.NewTextHandler(io.Discard, nil)), rpo, nil)
+    name := "Human Name"
+    r.handle(downloader.Event{ID: dl.ID, GID: "g", Type: downloader.EventMeta, Meta: &downloader.Meta{Name: &name}})
+    got, _ := rpo.Get(context.Background(), dl.ID)
+    if got.Name != name { t.Fatalf("name not updated: %q", got.Name) }
+}
+
 // TestHandleStartDoesNotOverrideStatus ensures that Start events do not
 // resurrect downloads that have been paused or cancelled by the user before
 // the downloader emitted the start signal.


### PR DESCRIPTION
- Added `Name` string to Download model (read-only in API).
- Extended downloader events with `EventMeta` carrying optional name.
- Aria2 adapter derives human-friendly names (torrent info.name, file path, HTTP last segment, magnet dn).
- Reconciler persists Name updates on `EventMeta`.
- API middleware rejects POST bodies setting name.
- OpenAPI spec + README updated to document read-only Name.
- Added unit tests for adapter name extraction, reconciler updates, and handler validation.