### PR TITLE
feat(model): add file list to Download object

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Fields returned by the downloads API:
 | `source`        | string | Download source link (magnet URI, HTTP URL, etc.)                           |
 | `targetPath`    | string | Destination path for the download                                           |
 | `name`          | string | Human-friendly display name from the downloader (read-only, optional)       |
+| `files`         | array  | Read-only list of file entries (when available). Each file has `path`, optional `length` and `completed`. |
 | `status`        | string | Current status. One of `Queued`, `Active`, `Paused`, `Complete`, `Cancelled`, `Failed` (read-only) |
 | `desiredStatus` | string | Desired status. Same enum as `status`                                       |
 | `createdAt`     | string | RFC3339 timestamp when the download was created (read-only)                 |

--- a/api/v1/errors.go
+++ b/api/v1/errors.go
@@ -10,5 +10,6 @@ var (
     ErrContentType = errors.New("Content-Type must be application/json")
     ErrMagnetURI = errors.New("invalid magnet link")
     ErrReadOnlyName = errors.New("name is read-only and cannot be set")
+    ErrReadOnlyFiles = errors.New("files is read-only and cannot be set")
 
 )

--- a/api/v1/middleware.go
+++ b/api/v1/middleware.go
@@ -39,6 +39,12 @@ func MiddlewareDownloadValidation(next http.Handler) http.Handler {
 			http.Error(w, ErrReadOnlyName.Error(), http.StatusBadRequest)
 			return
 		}
+        // Enforce read-only fields: reject if client sets files.
+        if len(dl.Files) > 0 {
+            markErr(w, ErrReadOnlyFiles)
+            http.Error(w, ErrReadOnlyFiles.Error(), http.StatusBadRequest)
+            return
+        }
 
 		ctx := context.WithValue(r.Context(), ctxKeyDownload{}, dl)
 		next.ServeHTTP(w, r.WithContext(ctx))

--- a/index.yaml
+++ b/index.yaml
@@ -182,6 +182,12 @@ components:
           description: Human-friendly display name provided by downloader
           readOnly: true
           example: "Some.Movie.2024.1080p.mkv"
+        files:
+          type: array
+          description: Read-only list of files in this download (when available)
+          items:
+            $ref: "#/components/schemas/DownloadFile"
+          readOnly: true
         status:
           $ref: "#/components/schemas/DownloadStatus"
           readOnly: true
@@ -225,6 +231,25 @@ components:
           enum: ["Active", "Resume", "Paused", "Cancelled"]
       required:
         - desiredStatus
+
+    DownloadFile:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+          description: Relative path or filename
+          example: "Show.S01/E01.mkv"
+        length:
+          type: integer
+          format: int64
+          description: File size in bytes (if known)
+          example: 1048576
+        completed:
+          type: integer
+          format: int64
+          description: Bytes completed for this file (if known)
+          example: 524288
 
     DownloadStatus:
       type: string

--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -17,9 +17,23 @@ type Download struct {
     TargetPath    string         `json:"targetPath"`
     // Name is a read-only field populated by the downloader via events.
     Name          string         `json:"name,omitempty"`
+    // Files is an optional, read-only list of files for this download.
+    // It is populated by downloader adapters when available.
+    Files         []DownloadFile `json:"files,omitempty"`
     Status        DownloadStatus `json:"status"`
     DesiredStatus DownloadStatus `json:"desiredStatus,omitempty"`
     CreatedAt     time.Time      `json:"createdAt"`
+}
+
+// DownloadFile represents a single file within a multi-file download.
+// All fields are optional, depending on downloader capabilities.
+type DownloadFile struct {
+    // Path is a relative path or filename for the file within the download.
+    Path      string `json:"path"`
+    // Length is the size of the file in bytes, if known.
+    Length    int64  `json:"length,omitempty"`
+    // Completed is the number of bytes downloaded for this file, if known.
+    Completed int64  `json:"completed,omitempty"`
 }
 
 // Possible DownloadStatus values.
@@ -61,11 +75,16 @@ func (d *Download) FromJSON(r io.Reader) error { return json.NewDecoder(r).Decod
 
 // Clone returns a copy of the download. The receiver is left unchanged.
 func (d *Download) Clone() *Download {
-	if d == nil {
-		return nil
-	}
-	cp := *d
-	return &cp
+    if d == nil {
+        return nil
+    }
+    cp := *d
+    // Deep copy Files slice to avoid data races through shared backing arrays.
+    if len(d.Files) > 0 {
+        cp.Files = make([]DownloadFile, len(d.Files))
+        copy(cp.Files, d.Files)
+    }
+    return &cp
 }
 
 // Clone returns copies of each download in the slice.

--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -1,5 +1,9 @@
 package downloader
 
+import (
+    "github.com/tinoosan/torrus/internal/data"
+)
+
 // Event represents a state change or progress update from a downloader.
 //
 // Type indicates what kind of event occurred. For terminal events
@@ -42,5 +46,8 @@ type Progress struct {
 // Meta carries optional metadata about a download that should be persisted
 // by the reconciler, such as the resolved resource name.
 type Meta struct {
-    Name *string
+    Name  *string
+    // Files is an optional list of files for this download, if available.
+    // Adapters may populate it when they can fetch details from the backend.
+    Files *[]data.DownloadFile
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -106,6 +106,20 @@ func (r *Reconciler) handle(e downloader.Event) {
                 r.log.Info("updated meta", "id", e.ID, "name", *e.Meta.Name)
             }
         }
+        if e.Meta.Files != nil {
+            // Persist files list (read-only field populated by downloader)
+            _, err := r.repo.Update(r.ctx, e.ID, func(dl *data.Download) error {
+                // Replace the slice to reflect latest snapshot from downloader
+                dl.Files = make([]data.DownloadFile, len(*e.Meta.Files))
+                copy(dl.Files, *e.Meta.Files)
+                return nil
+            })
+            if err != nil {
+                r.log.Error("update files", "id", e.ID, "err", err)
+            } else {
+                r.log.Info("updated files", "id", e.ID, "count", len(*e.Meta.Files))
+            }
+        }
         return
     case downloader.EventProgress:
         if e.Progress != nil {


### PR DESCRIPTION
- Added `Files []DownloadFile` to `Download` model
- New `DownloadFile` struct with Path, Length, Completed fields
- Marked JSON as `files,omitempty` so absent if downloader doesn’t provide info
- Keeps API backward-compatible; enriches downloads with optional per-file details