### PR TITLE
feat(downloads): add generic file-collision policy (error | overwrite | rename)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Torrus exposes a JSON-over-HTTP interface for orchestrating downloads.
 - **Pluggable downloader** – The API delegates download work to a backend component. A no-op backend is used by default, but alternate downloaders (e.g., Aria2) can be enabled through configuration.
 - **Port** – The service listens on port `9090` by default.
 
+## Configuration
+
+- `TORRUS_CONFLICT_POLICY`: Controls how to handle existing target files when starting or resuming downloads. Values:
+  - `error` (default): Fail if a conflicting file exists. API returns HTTP 409 on PATCH when a start/resume hits a conflict.
+  - `overwrite`: Replace existing files where supported by the backend.
+  - `rename`: Create a unique filename (backend default behavior, e.g., auto-renaming in aria2).
+
+Other existing environment variables:
+- `TORRUS_CLIENT`: Selects downloader backend (`aria2` to enable aria2 adapter; defaults to noop).
+- `ARIA2_RPC_URL`, `ARIA2_SECRET`, `ARIA2_POLL_MS`: Configure the aria2 client and polling interval.
+
 ## Endpoints (v1)
 
 ### Downloads
@@ -78,6 +89,7 @@ Request body:
 { "desiredStatus": "Active|Resume|Paused|Cancelled" }
 ```
 Responds with `200 OK` and the updated [Download](#download-object).
+May return `409 Conflict` when `TORRUS_CONFLICT_POLICY=error` and a conflicting file already exists at the target.
 
 #### Download Object
 Fields returned by the downloads API:

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -143,22 +143,26 @@ func (dh *DownloadHandler) UpdateDownload(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	updated, err := dh.svc.UpdateDesiredStatus(r.Context(), id, data.DownloadStatus(body.DesiredStatus))
-	if err != nil {
-		switch err {
-		case data.ErrNotFound:
-			markErr(w, err)
-			http.Error(w, "Not found", http.StatusNotFound)
-			return
-		case data.ErrBadStatus:
-			markErr(w, err)
+    updated, err := dh.svc.UpdateDesiredStatus(r.Context(), id, data.DownloadStatus(body.DesiredStatus))
+    if err != nil {
+        switch err {
+        case data.ErrNotFound:
+            markErr(w, err)
+            http.Error(w, "Not found", http.StatusNotFound)
+            return
+        case data.ErrBadStatus:
+            markErr(w, err)
             http.Error(w, "Invalid desiredStatus (allowed: Active|Resume|Paused|Cancelled)", http.StatusBadRequest)
             return
-		default:
-			markErr(w, err)
-			http.Error(w, "failed to update", http.StatusInternalServerError)
-			return
-		}
+        case data.ErrConflict:
+            markErr(w, err)
+            http.Error(w, "Conflict: target file exists", http.StatusConflict)
+            return
+        default:
+            markErr(w, err)
+            http.Error(w, "failed to update", http.StatusInternalServerError)
+            return
+        }
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = updated.ToJSON(w)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/downloader"
 	aria2dl "github.com/tinoosan/torrus/internal/downloader/aria2"
+    "github.com/tinoosan/torrus/internal/downloadcfg"
 	"github.com/tinoosan/torrus/internal/reconciler"
 	"github.com/tinoosan/torrus/internal/repo"
 	"github.com/tinoosan/torrus/internal/router"
@@ -113,7 +114,10 @@ func main() {
 		dlr = downloader.NewNoopDownloader()
 	}
 
-	downloadSvc := service.NewDownload(downloadRepo, dlr)
+    // Read global collision policy
+    pol := downloadcfg.ParseCollisionPolicy(strings.ToLower(os.Getenv("TORRUS_CONFLICT_POLICY")))
+
+    downloadSvc := service.NewDownload(downloadRepo, dlr, pol)
 
 	rec := reconciler.New(logger, downloadRepo, events)
 	rec.Run()

--- a/index.yaml
+++ b/index.yaml
@@ -119,6 +119,13 @@ paths:
           $ref: "#/components/responses/PlainError"
         "404":
           $ref: "#/components/responses/PlainError"
+        "409":
+          description: Conflict due to existing target file when policy=error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Conflict: target file exists"
         "415":
           $ref: "#/components/responses/PlainError"
         "500":

--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -62,6 +62,8 @@ var (
 	ErrInvalidSource = errors.New("invalid source")
 	// ErrTargetPath signals that the provided target path is invalid.
 	ErrTargetPath = errors.New("invalid target path")
+    // ErrConflict signals a file collision based on collision policy.
+    ErrConflict = errors.New("file conflict")
 )
 
 // ToJSON writes the slice of downloads as JSON to the writer.

--- a/internal/downloadcfg/policy.go
+++ b/internal/downloadcfg/policy.go
@@ -1,0 +1,31 @@
+package downloadcfg
+
+// CollisionPolicy defines how to handle existing target files.
+// Values: "error" | "overwrite" | "rename".
+type CollisionPolicy string
+
+const (
+    CollisionError     CollisionPolicy = "error"
+    CollisionOverwrite CollisionPolicy = "overwrite"
+    CollisionRename    CollisionPolicy = "rename"
+)
+
+// StartOptions carries downloader-agnostic options for starting/resuming.
+type StartOptions struct {
+    Policy CollisionPolicy
+}
+
+// ParseCollisionPolicy converts a string to a CollisionPolicy with default.
+func ParseCollisionPolicy(s string) CollisionPolicy {
+    switch CollisionPolicy(s) {
+    case CollisionOverwrite:
+        return CollisionOverwrite
+    case CollisionRename:
+        return CollisionRename
+    case CollisionError:
+        fallthrough
+    default:
+        return CollisionError
+    }
+}
+

--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tinoosan/torrus/internal/aria2" // your Client
 	"github.com/tinoosan/torrus/internal/data"
 	"github.com/tinoosan/torrus/internal/downloader" // the Downloader interface
+    "github.com/tinoosan/torrus/internal/downloadcfg"
 )
 
 // Adapter implements the Downloader interface using an aria2 JSON-RPC client.
@@ -149,7 +150,7 @@ func (a *Adapter) tokenParam() []interface{} {
 }
 
 // Start: aria2.addUri([token?, [uris], options])
-func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) {
+func (a *Adapter) Start(ctx context.Context, dl *data.Download, o downloadcfg.StartOptions) (string, error) {
 	params := make([]interface{}, 0, 3)
 	if tok := a.tokenParam(); tok != nil {
 		params = append(params, tok...)
@@ -159,6 +160,10 @@ func (a *Adapter) Start(ctx context.Context, dl *data.Download) (string, error) 
 	if dl.TargetPath != "" {
 		opts["dir"] = dl.TargetPath
 	}
+    // Map generic collision policy to aria2 options
+    for k, v := range mapPolicyToAria2(o.Policy) {
+        opts[k] = v
+    }
 	params = append(params, opts)
 
 	res, err := a.call(ctx, "aria2.addUri", params)
@@ -213,9 +218,13 @@ func (a *Adapter) Pause(ctx context.Context, dl *data.Download) error {
 }
 
 // Resume: aria2.unpause([token?, gid])
-func (a *Adapter) Resume(ctx context.Context, dl *data.Download) error {
-	params := append(a.tokenParam(), dl.GID)
-	_, err := a.call(ctx, "aria2.unpause", params)
+func (a *Adapter) Resume(ctx context.Context, dl *data.Download, o downloadcfg.StartOptions) error {
+    // Apply collision policy via changeOption before unpause
+    if err := a.changeOption(ctx, dl.GID, mapPolicyToAria2(o.Policy)); err != nil {
+        return err
+    }
+    params := append(a.tokenParam(), dl.GID)
+    _, err := a.call(ctx, "aria2.unpause", params)
 	if err != nil {
 		return err
 	}
@@ -256,6 +265,34 @@ func (a *Adapter) Resume(ctx context.Context, dl *data.Download) error {
 		a.rep.Report(downloader.Event{ID: dl.ID, GID: gid, Type: downloader.EventMeta, Meta: &meta})
 	}
 	return nil
+}
+
+// changeOption: aria2.changeOption([token?, gid, options])
+func (a *Adapter) changeOption(ctx context.Context, gid string, opts map[string]string) error {
+    if opts == nil || len(opts) == 0 {
+        return nil
+    }
+    params := make([]interface{}, 0, 3)
+    if tok := a.tokenParam(); tok != nil {
+        params = append(params, tok...)
+    }
+    params = append(params, gid)
+    params = append(params, opts)
+    _, err := a.call(ctx, "aria2.changeOption", params)
+    return err
+}
+
+func mapPolicyToAria2(p downloadcfg.CollisionPolicy) map[string]string {
+    switch p {
+    case downloadcfg.CollisionOverwrite:
+        return map[string]string{"allow-overwrite": "true", "auto-file-renaming": "false"}
+    case downloadcfg.CollisionRename:
+        return map[string]string{"allow-overwrite": "false", "auto-file-renaming": "true"}
+    case downloadcfg.CollisionError:
+        fallthrough
+    default:
+        return map[string]string{"allow-overwrite": "false", "auto-file-renaming": "false"}
+    }
 }
 
 // Cancel: aria2.remove([token?, gid])

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tinoosan/torrus/internal/aria2"
 	"github.com/tinoosan/torrus/internal/data"
 	"github.com/tinoosan/torrus/internal/downloader"
+    "github.com/tinoosan/torrus/internal/downloadcfg"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -88,7 +89,7 @@ func TestAdapterStart(t *testing.T) {
 			}
 		})
 		a, events := newTestAdapterWithEvents(t, "secret", rt)
-		gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 		if err != nil {
 			t.Fatalf("Start error: %v", err)
 		}
@@ -132,7 +133,7 @@ func TestAdapterStart(t *testing.T) {
 			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
 		})
 		a := newTestAdapter(t, "", rt)
-		gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 		if err == nil {
 			t.Fatalf("expected error")
 		}
@@ -159,38 +160,44 @@ func TestAdapterResumeEmitsMeta(t *testing.T) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		switch call {
-		case 1:
-			if req.Method != "aria2.unpause" {
-				t.Fatalf("method = %s", req.Method)
-			}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		case 2:
-			if req.Method != "aria2.tellStatus" {
-				t.Fatalf("expected tellStatus, got %s", req.Method)
-			}
-			// No metadata; adapter should fallback to magnet dn
-			result := map[string]any{}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		case 3:
-			if req.Method != "aria2.getFiles" {
-				t.Fatalf("expected getFiles, got %s", req.Method)
-			}
-			// No files known yet
-			result := []map[string]any{}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		default:
-			t.Fatalf("unexpected extra call %d", call)
-			return nil, nil
-		}
+    switch call {
+    case 1:
+        if req.Method != "aria2.changeOption" {
+            t.Fatalf("method = %s", req.Method)
+        }
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 2:
+        if req.Method != "aria2.unpause" {
+            t.Fatalf("method = %s", req.Method)
+        }
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 3:
+        if req.Method != "aria2.tellStatus" {
+            t.Fatalf("expected tellStatus, got %s", req.Method)
+        }
+        // No metadata; adapter should fallback to magnet dn
+        result := map[string]any{}
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 4:
+        if req.Method != "aria2.getFiles" {
+            t.Fatalf("expected getFiles, got %s", req.Method)
+        }
+        // No files known yet
+        result := []map[string]any{}
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    default:
+        t.Fatalf("unexpected extra call %d", call)
+        return nil, nil
+    }
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	if err := a.Resume(context.Background(), dl); err != nil {
-		t.Fatalf("resume: %v", err)
-	}
+    if err := a.Resume(context.Background(), dl, downloadcfg.StartOptions{}); err != nil {
+        t.Fatalf("resume: %v", err)
+    }
 	// Expect Meta with fallback name
 	ev := <-events
 	if ev.Type == downloader.EventStart {
@@ -249,7 +256,7 @@ func TestAdapterEmitsFilesMeta(t *testing.T) {
 		}
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -321,7 +328,7 @@ func TestAdapterFiltersDotFiles(t *testing.T) {
 		}
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -384,7 +391,7 @@ func TestAdapterStartMagnetFollowedBySwap(t *testing.T) {
 		}
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -409,39 +416,45 @@ func TestAdapterResumeFollowedBySwap(t *testing.T) {
 		if err := json.Unmarshal(b, &req); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		switch call {
-		case 1:
-			if req.Method != "aria2.unpause" {
-				t.Fatalf("call1 method=%s", req.Method)
-			}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		case 2:
-			if req.Method != "aria2.tellStatus" {
-				t.Fatalf("call2 method=%s", req.Method)
-			}
-			result := map[string]any{
-				"followedBy": []string{"realG"},
-				"files":      []map[string]any{{"path": "/tmp/x"}},
-			}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		case 3:
-			if req.Method != "aria2.getFiles" {
-				t.Fatalf("call3 method=%s", req.Method)
-			}
-			result := []map[string]any{{"path": "/downloads/real/file.mkv", "length": "5", "completedLength": "1"}}
-			rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
-			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
-		default:
-			t.Fatalf("unexpected call %d", call)
-			return nil, nil
-		}
+    switch call {
+    case 1:
+        if req.Method != "aria2.changeOption" {
+            t.Fatalf("call1 method=%s", req.Method)
+        }
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 2:
+        if req.Method != "aria2.unpause" {
+            t.Fatalf("call2 method=%s", req.Method)
+        }
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 3:
+        if req.Method != "aria2.tellStatus" {
+            t.Fatalf("call3 method=%s", req.Method)
+        }
+        result := map[string]any{
+            "followedBy": []string{"realG"},
+            "files":      []map[string]any{{"path": "/tmp/x"}},
+        }
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    case 4:
+        if req.Method != "aria2.getFiles" {
+            t.Fatalf("call4 method=%s", req.Method)
+        }
+        result := []map[string]any{{"path": "/downloads/real/file.mkv", "length": "5", "completedLength": "1"}}
+        rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: must(json.Marshal(result))})
+        return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+    default:
+        t.Fatalf("unexpected call %d", call)
+        return nil, nil
+    }
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	if err := a.Resume(context.Background(), dl); err != nil {
-		t.Fatalf("resume: %v", err)
-	}
+    if err := a.Resume(context.Background(), dl, downloadcfg.StartOptions{}); err != nil {
+        t.Fatalf("resume: %v", err)
+    }
 	// Expect GIDUpdate then Meta
 	ev := <-events
 	if ev.Type != downloader.EventGIDUpdate || ev.NewGID != "realG" {
@@ -460,7 +473,7 @@ func TestAdapterPauseCancel(t *testing.T) {
 		call      func(context.Context, *Adapter, *data.Download) error
 	}{
 		{"Pause", "aria2.pause", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Pause(ctx, d) }},
-		{"Resume", "aria2.unpause", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Resume(ctx, d) }},
+		{"Resume", "aria2.unpause", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Resume(ctx, d, downloadcfg.StartOptions{}) }},
 		{"Cancel", "aria2.remove", func(ctx context.Context, a *Adapter, d *data.Download) error { return a.Cancel(ctx, d) }},
 	}
 
@@ -477,9 +490,18 @@ func TestAdapterPauseCancel(t *testing.T) {
 				}
 				if first {
 					first = false
+					if m.name == "Resume" {
+						if req.Method != "aria2.changeOption" {
+							t.Fatalf("method = %s", req.Method)
+						}
+						rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)})
+						return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(rb)), Header: make(http.Header)}, nil
+					}
 					if req.Method != m.rpcMethod {
 						t.Fatalf("method = %s", req.Method)
 					}
+				} else if m.name == "Resume" && req.Method == "aria2.unpause" {
+					// allow unpause as the second call
 				} else {
 					// For Resume, subsequent tellStatus and getFiles are expected; others should not hit here
 					if m.name != "Resume" || (req.Method != "aria2.tellStatus" && req.Method != "aria2.getFiles") {
@@ -490,15 +512,17 @@ func TestAdapterPauseCancel(t *testing.T) {
 					t.Fatalf("id = %s", req.ID)
 				}
 				// Return success for first call; for tellStatus provide empty result
-				if req.Method == m.rpcMethod {
+				if req.Method == m.rpcMethod || req.Method == "aria2.changeOption" {
 					if len(req.Params) != 2 {
 						t.Fatalf("params len = %d", len(req.Params))
 					}
 					if tok, _ := req.Params[0].(string); tok != "token:secret" {
 						t.Fatalf("token param = %v", req.Params[0])
 					}
-					if gid, _ := req.Params[1].(string); gid != dl.GID {
-						t.Fatalf("gid param = %v", req.Params[1])
+					if req.Method != "aria2.changeOption" {
+						if gid, _ := req.Params[1].(string); gid != dl.GID {
+							t.Fatalf("gid param = %v", req.Params[1])
+						}
 					}
 					resp := rpcResp{Jsonrpc: "2.0", ID: "torrus", Result: json.RawMessage(`"ok"`)}
 					rb, _ := json.Marshal(resp)
@@ -536,6 +560,7 @@ func TestAdapterPauseCancel(t *testing.T) {
 		})
 	}
 }
+
 
 func TestAdapterHandleNotification(t *testing.T) {
 	events := make(chan downloader.Event, 2)
@@ -619,7 +644,7 @@ func TestAdapterMetadataCompleteTriggersFollowedBySwap(t *testing.T) {
 		}
 	})
 	a, events := newTestAdapterWithEvents(t, "secret", rt)
-	gid, err := a.Start(context.Background(), dl)
+    gid, err := a.Start(context.Background(), dl, downloadcfg.StartOptions{})
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1,10 +1,11 @@
 package downloader
 
 import (
-	"context"
-	"errors"
+    "context"
+    "errors"
 
-	"github.com/tinoosan/torrus/internal/data"
+    "github.com/tinoosan/torrus/internal/data"
+    "github.com/tinoosan/torrus/internal/downloadcfg"
 )
 
 // ErrNotFound is returned when the downloader cannot locate a download by ID.
@@ -12,9 +13,9 @@ var ErrNotFound = errors.New("downloader not found")
 
 // Downloader defines the operations required to manage a download's lifecycle.
 type Downloader interface {
-    Start(ctx context.Context, d *data.Download) (string, error)
+    Start(ctx context.Context, d *data.Download, opts downloadcfg.StartOptions) (string, error)
     Pause(ctx context.Context, d *data.Download) error
-    Resume(ctx context.Context, d *data.Download) error
+    Resume(ctx context.Context, d *data.Download, opts downloadcfg.StartOptions) error
     Cancel(ctx context.Context, d *data.Download) error
 }
 

--- a/internal/downloader/noop.go
+++ b/internal/downloader/noop.go
@@ -1,11 +1,12 @@
 package downloader
 
 import (
-	"context"
-	"fmt"
-	"strconv"
+    "context"
+    "fmt"
+    "strconv"
 
-	"github.com/tinoosan/torrus/internal/data"
+    "github.com/tinoosan/torrus/internal/data"
+    "github.com/tinoosan/torrus/internal/downloadcfg"
 )
 
 // noopDownloader implements Downloader but only logs calls.
@@ -18,9 +19,9 @@ func NewNoopDownloader() Downloader {
 }
 
 // Start logs the start request and returns the download ID as a fake GID.
-func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) (string, error) {
-	fmt.Println("noop: start", dl.ID)
-	return strconv.FormatInt(int64(dl.ID), 10), nil
+func (d *noopDownloader) Start(ctx context.Context, dl *data.Download, _ downloadcfg.StartOptions) (string, error) {
+    fmt.Println("noop: start", dl.ID)
+    return strconv.FormatInt(int64(dl.ID), 10), nil
 }
 
 // Pause logs the pause request and does nothing else.
@@ -30,7 +31,7 @@ func (d *noopDownloader) Pause(ctx context.Context, dl *data.Download) error {
 }
 
 // Resume logs the resume request and does nothing else.
-func (d *noopDownloader) Resume(ctx context.Context, dl *data.Download) error {
+func (d *noopDownloader) Resume(ctx context.Context, dl *data.Download, _ downloadcfg.StartOptions) error {
     fmt.Println("noop: resume", dl.ID)
     return nil
 }

--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -1,18 +1,19 @@
 package service
 
 import (
-	"context"
-	"errors"
-	"testing"
+    "context"
+    "errors"
+    "testing"
 
-	"github.com/tinoosan/torrus/internal/data"
-	"github.com/tinoosan/torrus/internal/repo"
+    "github.com/tinoosan/torrus/internal/data"
+    "github.com/tinoosan/torrus/internal/downloadcfg"
+    "github.com/tinoosan/torrus/internal/repo"
 )
 
 type stubDownloader struct {
-    startFn  func(ctx context.Context, d *data.Download) (string, error)
+    startFn  func(ctx context.Context, d *data.Download, o downloadcfg.StartOptions) (string, error)
     pauseFn  func(ctx context.Context, d *data.Download) error
-    resumeFn func(ctx context.Context, d *data.Download) error
+    resumeFn func(ctx context.Context, d *data.Download, o downloadcfg.StartOptions) error
     cancelFn func(ctx context.Context, d *data.Download) error
 
     started   bool
@@ -21,12 +22,12 @@ type stubDownloader struct {
     cancelled bool
 }
 
-func (s *stubDownloader) Start(ctx context.Context, d *data.Download) (string, error) {
-	s.started = true
-	if s.startFn != nil {
-		return s.startFn(ctx, d)
-	}
-	return "gid", nil
+func (s *stubDownloader) Start(ctx context.Context, d *data.Download, o downloadcfg.StartOptions) (string, error) {
+    s.started = true
+    if s.startFn != nil {
+        return s.startFn(ctx, d, o)
+    }
+    return "gid", nil
 }
 func (s *stubDownloader) Pause(ctx context.Context, d *data.Download) error {
     s.paused = true
@@ -35,10 +36,10 @@ func (s *stubDownloader) Pause(ctx context.Context, d *data.Download) error {
     }
     return nil
 }
-func (s *stubDownloader) Resume(ctx context.Context, d *data.Download) error {
+func (s *stubDownloader) Resume(ctx context.Context, d *data.Download, o downloadcfg.StartOptions) error {
     s.resumed = true
     if s.resumeFn != nil {
-        return s.resumeFn(ctx, d)
+        return s.resumeFn(ctx, d, o)
     }
     return nil
 }
@@ -55,9 +56,9 @@ func TestUpdateDesiredStatus(t *testing.T) {
 
 	t.Run("to Active starts and sets gid", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
-		d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t"})
-		dl := &stubDownloader{startFn: func(ctx context.Context, d *data.Download) (string, error) { return "g", nil }}
-		svc := NewDownload(r, dl)
+    d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t"})
+    dl := &stubDownloader{startFn: func(ctx context.Context, d *data.Download, _ downloadcfg.StartOptions) (string, error) { return "g", nil }}
+    svc := NewDownload(r, dl, downloadcfg.CollisionError)
 
 		got, err := svc.UpdateDesiredStatus(ctx, d.ID, data.StatusActive)
 		if err != nil {
@@ -74,8 +75,8 @@ func TestUpdateDesiredStatus(t *testing.T) {
     t.Run("to Paused pauses when gid", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
 		d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t", GID: "g", Status: data.StatusActive})
-		dl := &stubDownloader{}
-		svc := NewDownload(r, dl)
+    dl := &stubDownloader{}
+    svc := NewDownload(r, dl, downloadcfg.CollisionError)
 
 		got, err := svc.UpdateDesiredStatus(ctx, d.ID, data.StatusPaused)
 		if err != nil {
@@ -93,7 +94,7 @@ func TestUpdateDesiredStatus(t *testing.T) {
         r := repo.NewInMemoryDownloadRepo()
         d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t", GID: "g", Status: data.StatusPaused})
         dl := &stubDownloader{}
-        svc := NewDownload(r, dl)
+        svc := NewDownload(r, dl, downloadcfg.CollisionError)
 
         got, err := svc.UpdateDesiredStatus(ctx, d.ID, data.StatusResume)
         if err != nil {
@@ -110,8 +111,8 @@ func TestUpdateDesiredStatus(t *testing.T) {
 	t.Run("to Cancelled cancels and clears gid", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
 		d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t", GID: "g", Status: data.StatusActive})
-		dl := &stubDownloader{}
-		svc := NewDownload(r, dl)
+    dl := &stubDownloader{}
+    svc := NewDownload(r, dl, downloadcfg.CollisionError)
 
 		got, err := svc.UpdateDesiredStatus(ctx, d.ID, data.StatusCancelled)
 		if err != nil {
@@ -127,9 +128,9 @@ func TestUpdateDesiredStatus(t *testing.T) {
 
 	t.Run("downloader error sets failed", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
-		d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t"})
-		dl := &stubDownloader{startFn: func(ctx context.Context, d *data.Download) (string, error) { return "", errors.New("boom") }}
-		svc := NewDownload(r, dl)
+    d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t"})
+    dl := &stubDownloader{startFn: func(ctx context.Context, d *data.Download, _ downloadcfg.StartOptions) (string, error) { return "", errors.New("boom") }}
+    svc := NewDownload(r, dl, downloadcfg.CollisionError)
 
 		_, err := svc.UpdateDesiredStatus(ctx, d.ID, data.StatusActive)
 		if err == nil {
@@ -143,7 +144,7 @@ func TestUpdateDesiredStatus(t *testing.T) {
 
 	t.Run("invalid status", func(t *testing.T) {
 		r := repo.NewInMemoryDownloadRepo()
-		svc := NewDownload(r, &stubDownloader{})
+    svc := NewDownload(r, &stubDownloader{}, downloadcfg.CollisionError)
 		_, err := svc.UpdateDesiredStatus(ctx, 1, data.StatusQueued)
 		if !errors.Is(err, data.ErrBadStatus) {
 			t.Fatalf("expected ErrBadStatus, got %v", err)


### PR DESCRIPTION
Introduce a downloader-agnostic file-collision policy so all downloader implementations (aria2 today, others later) consistently handle “target file already exists” scenarios. Policies: error, overwrite, rename. The service owns the policy; each adapter maps it to its backend-specific mechanism.

- Domain: add CollisionPolicy and StartOptions; add ErrConflict.
- Interface: Start/Resume accept options.
- Aria2 adapter: map to allow-overwrite and auto-file-renaming; apply via addUri/changeOption.
- Service: read TORRUS_CONFLICT_POLICY (default error); pass options; map conflicts to 409.
- API: PATCH returns 409 Conflict when policy=error.
- Tests/docs/OpenAPI updated.

Acceptance
- With TORRUS_CONFLICT_POLICY=error, starting/resuming into an existing path produces HTTP 409.
- With overwrite, existing files are replaced.
- With rename, duplicates are created with unique names.
