### PR TITLE
feat(api): add DELETE /v1/downloads/{id} with optional file removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,25 @@ Idempotency details:
 - Torrus computes a stable fingerprint `sha256(normalize(source), normalize(targetPath))` where `normalize` trims whitespace and cleans the target path (via `filepath.Clean`).
 - On Unix, paths remain case-sensitive. A Windows-specific normalization (e.g., lowercasing) can be added later if needed.
 
-**PATCH /v1/downloads/{id}**  
-Update the desired status of a download.  
+**PATCH /v1/downloads/{id}**
+Update the desired status of a download.
 Path parameters:
-- `id` — numeric identifier  
+- `id` — numeric identifier
 Request body:
 ```json
 { "desiredStatus": "Active|Resume|Paused|Cancelled" }
 ```
 Responds with `200 OK` and the updated [Download](#download-object).
 May return `409 Conflict` when a conflicting file already exists at the target.
+
+**DELETE /v1/downloads/{id}**
+Delete a download. Optional JSON body:
+```json
+{ "deleteFiles": true }
+```
+- `deleteFiles=true` removes on-disk files and control artifacts before deleting the entry.
+- `deleteFiles=false` (default) only cancels and deletes the entry.
+Returns `204 No Content` on success. Responds with `404` if the ID is not found.
 
 #### Download Object
 Fields returned by the downloads API:

--- a/api/v1/handlers_test.go
+++ b/api/v1/handlers_test.go
@@ -1,34 +1,34 @@
 package v1_test
 
 import (
-    "bytes"
-    "encoding/json"
-    "context"
-    "io"
-    "log/slog"
-    "net/http"
-    "net/http/httptest"
-    "strconv"
-    "strings"
-    "testing"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
 
-    "github.com/tinoosan/torrus/internal/downloader"
-    internaldata "github.com/tinoosan/torrus/internal/data"
-    "github.com/tinoosan/torrus/internal/repo"
-    "github.com/tinoosan/torrus/internal/router"
-    "github.com/tinoosan/torrus/internal/service"
+	internaldata "github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/downloader"
+	"github.com/tinoosan/torrus/internal/repo"
+	"github.com/tinoosan/torrus/internal/router"
+	"github.com/tinoosan/torrus/internal/service"
 )
 
 const testToken = "testtoken"
 
 func setup(t *testing.T) http.Handler {
-    t.Helper()
-    t.Setenv("TORRUS_API_TOKEN", testToken)
-    logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-    repo := repo.NewInMemoryDownloadRepo()
-    dlr := downloader.NewNoopDownloader()
-    svc := service.NewDownload(repo, dlr)
-    return router.New(logger, svc)
+	t.Helper()
+	t.Setenv("TORRUS_API_TOKEN", testToken)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo := repo.NewInMemoryDownloadRepo()
+	dlr := downloader.NewNoopDownloader()
+	svc := service.NewDownload(repo, dlr)
+	return router.New(logger, svc)
 }
 
 func authReq(r *http.Request) {
@@ -123,53 +123,53 @@ func TestDownloadsLifecycle(t *testing.T) {
 }
 
 func TestPostIdempotent(t *testing.T) {
-    h := setup(t)
+	h := setup(t)
 
-    body := bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file"}`)
-    req := httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
-    authReq(req)
-    req.Header.Set("Content-Type", "application/json")
-    rr := httptest.NewRecorder()
-    h.ServeHTTP(rr, req)
-    if rr.Code != http.StatusCreated {
-        t.Fatalf("expected 201, got %d", rr.Code)
-    }
-    var first map[string]any
-    _ = json.NewDecoder(rr.Body).Decode(&first)
+	body := bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+	var first map[string]any
+	_ = json.NewDecoder(rr.Body).Decode(&first)
 
-    // Same request again => 200 and same id
-    body2 := bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file"}`)
-    req2 := httptest.NewRequest(http.MethodPost, "/v1/downloads", body2)
-    authReq(req2)
-    req2.Header.Set("Content-Type", "application/json")
-    rr2 := httptest.NewRecorder()
-    h.ServeHTTP(rr2, req2)
-    if rr2.Code != http.StatusOK {
-        t.Fatalf("expected 200, got %d", rr2.Code)
-    }
-    var second map[string]any
-    _ = json.NewDecoder(rr2.Body).Decode(&second)
-    if int(first["id"].(float64)) != int(second["id"].(float64)) {
-        t.Fatalf("ids differ: %v vs %v", first["id"], second["id"])
-    }
+	// Same request again => 200 and same id
+	body2 := bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file"}`)
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/downloads", body2)
+	authReq(req2)
+	req2.Header.Set("Content-Type", "application/json")
+	rr2 := httptest.NewRecorder()
+	h.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr2.Code)
+	}
+	var second map[string]any
+	_ = json.NewDecoder(rr2.Body).Decode(&second)
+	if int(first["id"].(float64)) != int(second["id"].(float64)) {
+		t.Fatalf("ids differ: %v vs %v", first["id"], second["id"])
+	}
 }
 
 func TestPostDownloadValidation(t *testing.T) {
-    h := setup(t)
+	h := setup(t)
 
-    tests := []struct {
-        name        string
-        contentType string
-        body        string
-        want        int
-    }{
-        {"wrong content-type", "text/plain", "{}", http.StatusUnsupportedMediaType},
-        {"unknown field", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","extra":1}`, http.StatusBadRequest},
-        {"missing target", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef"}`, http.StatusBadRequest},
-        {"body too large", "application/json", `{"source":"magnet:?xt=urn:btih:` + strings.Repeat("a", 1<<20) + `","targetPath":"/tmp"}`, http.StatusBadRequest},
-        {"name provided (read-only)", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","name":"hack"}`, http.StatusBadRequest},
-        {"files provided (read-only)", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","files":[{"path":"a.mkv"}]}`, http.StatusBadRequest},
-    }
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		want        int
+	}{
+		{"wrong content-type", "text/plain", "{}", http.StatusUnsupportedMediaType},
+		{"unknown field", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","extra":1}`, http.StatusBadRequest},
+		{"missing target", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef"}`, http.StatusBadRequest},
+		{"body too large", "application/json", `{"source":"magnet:?xt=urn:btih:` + strings.Repeat("a", 1<<20) + `","targetPath":"/tmp"}`, http.StatusBadRequest},
+		{"name provided (read-only)", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","name":"hack"}`, http.StatusBadRequest},
+		{"files provided (read-only)", "application/json", `{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp","files":[{"path":"a.mkv"}]}`, http.StatusBadRequest},
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -187,50 +187,136 @@ func TestPostDownloadValidation(t *testing.T) {
 	}
 }
 
+func TestDeleteDownload(t *testing.T) {
+	h := setup(t)
+
+	// create a download first
+	body := bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:abcdef","targetPath":"/tmp/file"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+	var created map[string]any
+	_ = json.NewDecoder(rr.Body).Decode(&created)
+	id := int(created["id"].(float64))
+
+	// delete without body
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/downloads/"+strconv.Itoa(id), nil)
+	authReq(delReq)
+	delRR := httptest.NewRecorder()
+	h.ServeHTTP(delRR, delReq)
+	if delRR.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", delRR.Code)
+	}
+
+	// deleting again should return 404
+	delReq2 := httptest.NewRequest(http.MethodDelete, "/v1/downloads/"+strconv.Itoa(id), nil)
+	authReq(delReq2)
+	delRR2 := httptest.NewRecorder()
+	h.ServeHTTP(delRR2, delReq2)
+	if delRR2.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 got %d", delRR2.Code)
+	}
+
+	// create another download for body tests
+	body = bytes.NewBufferString(`{"source":"magnet:?xt=urn:btih:aaaa","targetPath":"/tmp/file2"}`)
+	req = httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+	_ = json.NewDecoder(rr.Body).Decode(&created)
+	id2 := int(created["id"].(float64))
+
+	// delete with deleteFiles true
+	delBody := bytes.NewBufferString(`{"deleteFiles":true}`)
+	delReq3 := httptest.NewRequest(http.MethodDelete, "/v1/downloads/"+strconv.Itoa(id2), delBody)
+	authReq(delReq3)
+	delReq3.Header.Set("Content-Type", "application/json")
+	delRR3 := httptest.NewRecorder()
+	h.ServeHTTP(delRR3, delReq3)
+	if delRR3.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 got %d", delRR3.Code)
+	}
+
+	// bad json
+	badReq := httptest.NewRequest(http.MethodDelete, "/v1/downloads/1", strings.NewReader("{"))
+	authReq(badReq)
+	badReq.Header.Set("Content-Type", "application/json")
+	badRR := httptest.NewRecorder()
+	h.ServeHTTP(badRR, badReq)
+	if badRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", badRR.Code)
+	}
+
+	// wrong content-type
+	ctReq := httptest.NewRequest(http.MethodDelete, "/v1/downloads/1", strings.NewReader("{}"))
+	authReq(ctReq)
+	ctReq.Header.Set("Content-Type", "text/plain")
+	ctRR := httptest.NewRecorder()
+	h.ServeHTTP(ctRR, ctReq)
+	if ctRR.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", ctRR.Code)
+	}
+}
+
 func TestGetDownloadIncludesFiles(t *testing.T) {
-    // Build router manually to access repo
-    t.Setenv("TORRUS_API_TOKEN", testToken)
-    logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-    rpo := repo.NewInMemoryDownloadRepo()
-    dlr := downloader.NewNoopDownloader()
-    svc := service.NewDownload(rpo, dlr)
-    h := router.New(logger, svc)
+	// Build router manually to access repo
+	t.Setenv("TORRUS_API_TOKEN", testToken)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rpo := repo.NewInMemoryDownloadRepo()
+	dlr := downloader.NewNoopDownloader()
+	svc := service.NewDownload(rpo, dlr)
+	h := router.New(logger, svc)
 
-    // Seed a download with files
-    dl := &struct {
-        Source     string `json:"source"`
-        TargetPath string `json:"targetPath"`
-    }{"magnet:?xt=urn:btih:abcdef", "/tmp"}
+	// Seed a download with files
+	dl := &struct {
+		Source     string `json:"source"`
+		TargetPath string `json:"targetPath"`
+	}{"magnet:?xt=urn:btih:abcdef", "/tmp"}
 
-    // Create download via API
-    b := new(bytes.Buffer)
-    _ = json.NewEncoder(b).Encode(dl)
-    req := httptest.NewRequest(http.MethodPost, "/v1/downloads", b)
-    authReq(req)
-    req.Header.Set("Content-Type", "application/json")
-    rr := httptest.NewRecorder()
-    h.ServeHTTP(rr, req)
-    if rr.Code != http.StatusCreated { t.Fatalf("create status=%d", rr.Code) }
-    var created map[string]any
-    _ = json.NewDecoder(rr.Body).Decode(&created)
-    id := int(created["id"].(float64))
+	// Create download via API
+	b := new(bytes.Buffer)
+	_ = json.NewEncoder(b).Encode(dl)
+	req := httptest.NewRequest(http.MethodPost, "/v1/downloads", b)
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status=%d", rr.Code)
+	}
+	var created map[string]any
+	_ = json.NewDecoder(rr.Body).Decode(&created)
+	id := int(created["id"].(float64))
 
-    // Update repo to include files
-    _, _ = rpo.Update(context.Background(), id, func(d *internaldata.Download) error {
-        d.Files = []internaldata.DownloadFile{{Path: "ep1.mkv", Length: 1000}, {Path: "ep2.mkv", Completed: 100}}
-        return nil
-    })
+	// Update repo to include files
+	_, _ = rpo.Update(context.Background(), id, func(d *internaldata.Download) error {
+		d.Files = []internaldata.DownloadFile{{Path: "ep1.mkv", Length: 1000}, {Path: "ep2.mkv", Completed: 100}}
+		return nil
+	})
 
-    // GET by id should include files
-    req = httptest.NewRequest(http.MethodGet, "/v1/downloads/"+strconv.Itoa(id), nil)
-    authReq(req)
-    rr = httptest.NewRecorder()
-    h.ServeHTTP(rr, req)
-    if rr.Code != http.StatusOK { t.Fatalf("get status=%d", rr.Code) }
-    var got map[string]any
-    _ = json.NewDecoder(rr.Body).Decode(&got)
-    fs, ok := got["files"].([]any)
-    if !ok || len(fs) != 2 { t.Fatalf("files missing or wrong len: %#v", got["files"]) }
+	// GET by id should include files
+	req = httptest.NewRequest(http.MethodGet, "/v1/downloads/"+strconv.Itoa(id), nil)
+	authReq(req)
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get status=%d", rr.Code)
+	}
+	var got map[string]any
+	_ = json.NewDecoder(rr.Body).Decode(&got)
+	fs, ok := got["files"].([]any)
+	if !ok || len(fs) != 2 {
+		t.Fatalf("files missing or wrong len: %#v", got["files"])
+	}
 }
 
 func TestPatchDownload(t *testing.T) {
@@ -279,38 +365,41 @@ func TestPatchDownload(t *testing.T) {
 type conflictDL struct{}
 
 func (c *conflictDL) Start(ctx context.Context, d *internaldata.Download) (string, error) {
-    return "", internaldata.ErrConflict
+	return "", internaldata.ErrConflict
 }
 func (c *conflictDL) Pause(ctx context.Context, d *internaldata.Download) error { return nil }
 func (c *conflictDL) Resume(ctx context.Context, d *internaldata.Download) error {
-    return internaldata.ErrConflict
+	return internaldata.ErrConflict
 }
 func (c *conflictDL) Cancel(ctx context.Context, d *internaldata.Download) error { return nil }
+func (c *conflictDL) Purge(ctx context.Context, d *internaldata.Download) error  { return nil }
 
 func TestPatchConflictPolicyReturns409(t *testing.T) {
-    t.Setenv("TORRUS_API_TOKEN", testToken)
-    logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-    rpo := repo.NewInMemoryDownloadRepo()
-    dlr := &conflictDL{}
-    svc := service.NewDownload(rpo, dlr)
-    h := router.New(logger, svc)
+	t.Setenv("TORRUS_API_TOKEN", testToken)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rpo := repo.NewInMemoryDownloadRepo()
+	dlr := &conflictDL{}
+	svc := service.NewDownload(rpo, dlr)
+	h := router.New(logger, svc)
 
-    // Create download via API
-    body := bytes.NewBufferString(`{"source":"http://example.com/file.bin","targetPath":"/tmp"}`)
-    req := httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
-    authReq(req)
-    req.Header.Set("Content-Type", "application/json")
-    rr := httptest.NewRecorder()
-    h.ServeHTTP(rr, req)
-    if rr.Code != http.StatusCreated { t.Fatalf("create status=%d", rr.Code) }
+	// Create download via API
+	body := bytes.NewBufferString(`{"source":"http://example.com/file.bin","targetPath":"/tmp"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/downloads", body)
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create status=%d", rr.Code)
+	}
 
-    // Now PATCH desiredStatus Active -> should hit Start and return 409
-    req = httptest.NewRequest(http.MethodPatch, "/v1/downloads/1", strings.NewReader(`{"desiredStatus":"Active"}`))
-    authReq(req)
-    req.Header.Set("Content-Type", "application/json")
-    rr = httptest.NewRecorder()
-    h.ServeHTTP(rr, req)
-    if rr.Code != http.StatusConflict {
-        t.Fatalf("expected 409, got %d", rr.Code)
-    }
+	// Now PATCH desiredStatus Active -> should hit Start and return 409
+	req = httptest.NewRequest(http.MethodPatch, "/v1/downloads/1", strings.NewReader(`{"desiredStatus":"Active"}`))
+	authReq(req)
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rr.Code)
+	}
 }

--- a/index.yaml
+++ b/index.yaml
@@ -136,6 +136,35 @@ paths:
           $ref: "#/components/responses/PlainError"
         "500":
           $ref: "#/components/responses/PlainError"
+    delete:
+      tags: [Downloads]
+      summary: Delete a download
+      operationId: deleteDownload
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                deleteFiles:
+                  type: boolean
+                  description: |
+                    If true, remove on-disk files and control artifacts (e.g. .aria2) before deleting the entry.
+                    If false, only cancel/stop and delete the entry; files are left in place.
+                  default: false
+      responses:
+        "204":
+          description: Deleted
+        "400":
+          $ref: "#/components/responses/PlainError"
+        "404":
+          $ref: "#/components/responses/PlainError"
+        "409":
+          $ref: "#/components/responses/PlainError"
+        "500":
+          $ref: "#/components/responses/PlainError"
 
   /healthz:
     get:

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1,10 +1,10 @@
 package downloader
 
 import (
-    "context"
-    "errors"
+	"context"
+	"errors"
 
-    "github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/data"
 )
 
 // ErrNotFound is returned when the downloader cannot locate a download by ID.
@@ -12,14 +12,18 @@ var ErrNotFound = errors.New("downloader not found")
 
 // Downloader defines the operations required to manage a download's lifecycle.
 type Downloader interface {
-    Start(ctx context.Context, d *data.Download) (string, error)
-    Pause(ctx context.Context, d *data.Download) error
-    Resume(ctx context.Context, d *data.Download) error
-    Cancel(ctx context.Context, d *data.Download) error
+	Start(ctx context.Context, d *data.Download) (string, error)
+	Pause(ctx context.Context, d *data.Download) error
+	Resume(ctx context.Context, d *data.Download) error
+	Cancel(ctx context.Context, d *data.Download) error
+	// Purge removes on-disk files and control artifacts for the download.
+	// Implementations should best-effort cancel any active transfer and then
+	// delete associated data. It must be idempotent.
+	Purge(ctx context.Context, d *data.Download) error
 }
 
 // EventSource is implemented by downloaders that emit asynchronous events.
 // Reconciler wiring can launch Run(ctx) when available to process notifications.
 type EventSource interface {
-    Run(ctx context.Context)
+	Run(ctx context.Context)
 }

--- a/internal/downloader/noop.go
+++ b/internal/downloader/noop.go
@@ -1,11 +1,11 @@
 package downloader
 
 import (
-    "context"
-    "fmt"
-    "strconv"
+	"context"
+	"fmt"
+	"strconv"
 
-    "github.com/tinoosan/torrus/internal/data"
+	"github.com/tinoosan/torrus/internal/data"
 )
 
 // noopDownloader implements Downloader but only logs calls.
@@ -19,24 +19,30 @@ func NewNoopDownloader() Downloader {
 
 // Start logs the start request and returns the download ID as a fake GID.
 func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) (string, error) {
-    fmt.Println("noop: start", dl.ID)
-    return strconv.FormatInt(int64(dl.ID), 10), nil
+	fmt.Println("noop: start", dl.ID)
+	return strconv.FormatInt(int64(dl.ID), 10), nil
 }
 
 // Pause logs the pause request and does nothing else.
 func (d *noopDownloader) Pause(ctx context.Context, dl *data.Download) error {
-    fmt.Println("noop: pause", dl.ID)
-    return nil
+	fmt.Println("noop: pause", dl.ID)
+	return nil
 }
 
 // Resume logs the resume request and does nothing else.
 func (d *noopDownloader) Resume(ctx context.Context, dl *data.Download) error {
-    fmt.Println("noop: resume", dl.ID)
-    return nil
+	fmt.Println("noop: resume", dl.ID)
+	return nil
 }
 
 // Cancel logs the cancel request and does nothing else.
 func (d *noopDownloader) Cancel(ctx context.Context, dl *data.Download) error {
-    fmt.Println("noop: cancel", dl.ID)
-    return nil
+	fmt.Println("noop: cancel", dl.ID)
+	return nil
+}
+
+// Purge logs the purge request and does nothing else.
+func (d *noopDownloader) Purge(ctx context.Context, dl *data.Download) error {
+	fmt.Println("noop: purge", dl.ID)
+	return nil
 }

--- a/internal/repo/downloads.go
+++ b/internal/repo/downloads.go
@@ -28,25 +28,27 @@ type UpdateFields struct {
 
 // DownloadWriter defines write operations for downloads.
 type DownloadWriter interface {
-    Add(ctx context.Context, download *data.Download) (*data.Download, error)
-    Update(ctx context.Context, id int, mutate func(*data.Download) error) (*data.Download, error)
-    // AddWithFingerprint performs an atomic check-then-insert based on the
-    // provided fingerprint. If an existing row with the fingerprint exists,
-    // it returns that row and created=false. Otherwise it inserts the provided
-    // download, assigns an ID, and returns created=true.
-    AddWithFingerprint(ctx context.Context, download *data.Download, fingerprint string) (*data.Download, bool, error)
+	Add(ctx context.Context, download *data.Download) (*data.Download, error)
+	Update(ctx context.Context, id int, mutate func(*data.Download) error) (*data.Download, error)
+	// AddWithFingerprint performs an atomic check-then-insert based on the
+	// provided fingerprint. If an existing row with the fingerprint exists,
+	// it returns that row and created=false. Otherwise it inserts the provided
+	// download, assigns an ID, and returns created=true.
+	AddWithFingerprint(ctx context.Context, download *data.Download, fingerprint string) (*data.Download, bool, error)
+	// Delete removes the download with the given ID.
+	Delete(ctx context.Context, id int) error
 }
 
 // DownloadFinder extends lookup helpers
 type DownloadFinder interface {
-    // GetByFingerprint returns a download matched by the provided fingerprint,
-    // or data.ErrNotFound if none exists.
-    GetByFingerprint(ctx context.Context, fingerprint string) (*data.Download, error)
+	// GetByFingerprint returns a download matched by the provided fingerprint,
+	// or data.ErrNotFound if none exists.
+	GetByFingerprint(ctx context.Context, fingerprint string) (*data.Download, error)
 }
 
 // ExtendedRepo combines reader, writer and finder interfaces.
 type ExtendedRepo interface {
-    DownloadReader
-    DownloadWriter
-    DownloadFinder
+	DownloadReader
+	DownloadWriter
+	DownloadFinder
 }

--- a/internal/repo/inmem_test.go
+++ b/internal/repo/inmem_test.go
@@ -212,71 +212,84 @@ func TestInMemoryDownloadRepo_Concurrency(t *testing.T) {
 	}
 }
 
+func TestInMemoryDownloadRepo_Delete(t *testing.T) {
+	ctx := context.Background()
+	r := NewInMemoryDownloadRepo()
+	d, _ := r.Add(ctx, &data.Download{Source: "s", TargetPath: "t"})
+
+	if err := r.Delete(ctx, d.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := r.Get(ctx, d.ID); !errors.Is(err, data.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
 func TestAddWithFingerprint_IdempotentAndGetByFingerprint(t *testing.T) {
-    ctx := context.Background()
-    r := NewInMemoryDownloadRepo()
+	ctx := context.Background()
+	r := NewInMemoryDownloadRepo()
 
-    // First insert
-    d := &data.Download{Source: " s ", TargetPath: " t "}
-    got, created, err := r.AddWithFingerprint(ctx, d, "fp1")
-    if err != nil || !created {
-        t.Fatalf("expected created=true got err=%v created=%v", err, created)
-    }
-    if got.ID == 0 {
-        t.Fatalf("id not assigned")
-    }
+	// First insert
+	d := &data.Download{Source: " s ", TargetPath: " t "}
+	got, created, err := r.AddWithFingerprint(ctx, d, "fp1")
+	if err != nil || !created {
+		t.Fatalf("expected created=true got err=%v created=%v", err, created)
+	}
+	if got.ID == 0 {
+		t.Fatalf("id not assigned")
+	}
 
-    // Second insert with same fingerprint
-    d2 := &data.Download{Source: " s ", TargetPath: " t "}
-    got2, created2, err := r.AddWithFingerprint(ctx, d2, "fp1")
-    if err != nil || created2 {
-        t.Fatalf("expected created=false got err=%v created=%v", err, created2)
-    }
-    if got2.ID != got.ID {
-        t.Fatalf("expected same id got %d vs %d", got2.ID, got.ID)
-    }
+	// Second insert with same fingerprint
+	d2 := &data.Download{Source: " s ", TargetPath: " t "}
+	got2, created2, err := r.AddWithFingerprint(ctx, d2, "fp1")
+	if err != nil || created2 {
+		t.Fatalf("expected created=false got err=%v created=%v", err, created2)
+	}
+	if got2.ID != got.ID {
+		t.Fatalf("expected same id got %d vs %d", got2.ID, got.ID)
+	}
 
-    // Lookup by fingerprint
-    byfp, err := r.GetByFingerprint(ctx, "fp1")
-    if err != nil || byfp.ID != got.ID {
-        t.Fatalf("GetByFingerprint mismatch: %#v err=%v", byfp, err)
-    }
+	// Lookup by fingerprint
+	byfp, err := r.GetByFingerprint(ctx, "fp1")
+	if err != nil || byfp.ID != got.ID {
+		t.Fatalf("GetByFingerprint mismatch: %#v err=%v", byfp, err)
+	}
 }
 
 func TestAddWithFingerprint_ConcurrentSingleCreate(t *testing.T) {
-    ctx := context.Background()
-    r := NewInMemoryDownloadRepo()
+	ctx := context.Background()
+	r := NewInMemoryDownloadRepo()
 
-    const gor = 50
-    var wg sync.WaitGroup
-    ids := make(chan int, gor)
-    for i := 0; i < gor; i++ {
-        wg.Add(1)
-        go func() {
-            defer wg.Done()
-            d := &data.Download{Source: "s", TargetPath: "t"}
-            got, _, err := r.AddWithFingerprint(ctx, d, "samefp")
-            if err != nil {
-                t.Errorf("AddWithFingerprint: %v", err)
-                return
-            }
-            ids <- got.ID
-        }()
-    }
-    wg.Wait()
-    close(ids)
+	const gor = 50
+	var wg sync.WaitGroup
+	ids := make(chan int, gor)
+	for i := 0; i < gor; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d := &data.Download{Source: "s", TargetPath: "t"}
+			got, _, err := r.AddWithFingerprint(ctx, d, "samefp")
+			if err != nil {
+				t.Errorf("AddWithFingerprint: %v", err)
+				return
+			}
+			ids <- got.ID
+		}()
+	}
+	wg.Wait()
+	close(ids)
 
-    first := -1
-    for id := range ids {
-        if first == -1 {
-            first = id
-        } else if id != first {
-            t.Fatalf("saw different ids: %d vs %d", id, first)
-        }
-    }
+	first := -1
+	for id := range ids {
+		if first == -1 {
+			first = id
+		} else if id != first {
+			t.Fatalf("saw different ids: %d vs %d", id, first)
+		}
+	}
 
-    list, _ := r.List(ctx)
-    if len(list) != 1 {
-        t.Fatalf("expected 1 row, got %d", len(list))
-    }
+	list, _ := r.List(ctx)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(list))
+	}
 }

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -44,5 +44,9 @@ func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 	patch.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.UpdateDownload)
 	patch.Use(v1.MiddlewarePatchDesired)
 
+	// DELETEs
+	del := api.Methods("DELETE").Subrouter()
+	del.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.DeleteDownload)
+
 	return r
 }


### PR DESCRIPTION
## Summary
- add `DELETE /v1/downloads/{id}` to remove downloads
- extend downloader/service/repo layers with purge and delete support
- document and test new deletion workflow

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b4aa97e7108329bdd3fe2ebe3ec843