### PR TITLE
Cancel pending starts when downloads are deleted

### DIFF
--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -292,6 +292,9 @@ func isAria2GIDNotFoundError(err error) bool {
 
 // Cancel: aria2.remove([token?, gid])
 func (a *Adapter) Cancel(ctx context.Context, dl *data.Download) error {
+	if dl.GID == "" {
+		return downloader.ErrNotFound
+	}
 	params := append(a.tokenParam(), dl.GID)
 	_, err := a.call(ctx, "aria2.remove", params)
 	if err != nil {

--- a/internal/service/download_test.go
+++ b/internal/service/download_test.go
@@ -337,6 +337,18 @@ func TestDownloadService_Delete(t *testing.T) {
 		}
 	})
 
+	t.Run("cancel without gid", func(t *testing.T) {
+		d3, _ := r.Add(ctx, &data.Download{Source: "s3", TargetPath: "t3"})
+		dlr := &stubDownloader{}
+		svc := NewDownload(r, dlr)
+		if err := svc.Delete(ctx, d3.ID, false); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if !dlr.cancelled {
+			t.Fatalf("expected Cancel to be called even without gid")
+		}
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		dlr := &stubDownloader{}
 		svc := NewDownload(r, dlr)


### PR DESCRIPTION
## Summary
- track in-flight downloader starts and cancel them if the download is removed
- call `Cancel` even without a GID and handle empty GIDs in the aria2 adapter
- test deletion without a GID

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2e20ad08329a216a4d7cbcfbdf3