### PR TITLE
feat(repo+api): switch IDs to UUIDs and use map-backed repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ curl -X POST http://localhost:8080/v1/downloads \
   -d '{"source":"magnet:?xt=urn:btih:...","targetPath":"/downloads","desiredStatus":"Active"}'
 
 # Get a download by ID
-curl http://localhost:8080/v1/downloads/123
+curl http://localhost:8080/v1/downloads/2a1f8d7e-3b4c-4d5e-8f9a-1b2c3d4e5f60
 
 # Update download desired status
-curl -X PATCH http://localhost:8080/v1/downloads/123 \
+curl -X PATCH http://localhost:8080/v1/downloads/2a1f8d7e-3b4c-4d5e-8f9a-1b2c3d4e5f60 \
   -H "Content-Type: application/json" \
   -d '{"desiredStatus":"Paused"}'
 

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -88,12 +87,7 @@ func (dh *DownloadHandler) GetDownloads(w http.ResponseWriter, r *http.Request) 
 
 func (dh *DownloadHandler) GetDownload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		markErr(w, err)
-		http.Error(w, "Unable to convert ID", http.StatusBadRequest)
-		return
-	}
+	id := vars["id"]
 
 	dl, err := dh.svc.Get(r.Context(), id)
 	if err != nil {
@@ -138,12 +132,7 @@ func (dh *DownloadHandler) AddDownload(w http.ResponseWriter, r *http.Request) {
 
 func (dh *DownloadHandler) UpdateDownload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		markErr(w, err)
-		http.Error(w, "Unable to convert ID", http.StatusBadRequest)
-		return
-	}
+	id := vars["id"]
 
 	v := r.Context().Value(ctxKeyPatch{})
 	body, ok := v.(patchBody)
@@ -180,12 +169,7 @@ func (dh *DownloadHandler) UpdateDownload(w http.ResponseWriter, r *http.Request
 
 func (dh *DownloadHandler) DeleteDownload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	id, err := strconv.Atoi(vars["id"])
-	if err != nil {
-		markErr(w, err)
-		http.Error(w, "Unable to convert ID", http.StatusBadRequest)
-		return
-	}
+	id := vars["id"]
 
 	var body deleteBody
 	if r.Body != nil && r.ContentLength != 0 {

--- a/docs/persistence-and-repo.md
+++ b/docs/persistence-and-repo.md
@@ -22,7 +22,7 @@ state. Always work on the clone returned by repo methods.
 - GID is assigned on first `Start` and cleared on `Cancelled` or purge.
 
 ### ID & timestamps
-IDs auto-increment inside the repo (`nextID`). `CreatedAt` defaults in the
+IDs are UUID v4 strings generated on insert. `CreatedAt` defaults in the
 service when zero so tests can omit it safely.
 
 See [idempotency](idempotency.md) for fingerprinting logic and

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tinoosan/torrus
 go 1.24.4
 
 require (
+	github.com/google/uuid v1.3.1
 	github.com/gorilla/mux v1.8.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	nhooyr.io/websocket v1.8.9

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=

--- a/index.yaml
+++ b/index.yaml
@@ -78,10 +78,10 @@ paths:
       - name: id
         in: path
         required: true
-        description: Numeric download identifier
+        description: Download identifier
         schema:
-          type: integer
-          format: int32
+          type: string
+          format: uuid
     get:
       tags: [Downloads]
       summary: Get a download
@@ -201,10 +201,10 @@ components:
       additionalProperties: false
       properties:
         id:
-          type: integer
-          format: int32
+          type: string
+          format: uuid
           readOnly: true
-          example: 2
+          example: "2a1f8d7e-3b4c-4d5e-8f9a-1b2c3d4e5f60"
         gid:
           type: string
           nullable: true

--- a/internal/data/download.go
+++ b/internal/data/download.go
@@ -4,47 +4,46 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"strconv"
 	"time"
 )
 
 // Download represents a single file transfer managed by Torrus.
 // It tracks the source URI, destination path and current state.
 type Download struct {
-    ID            int            `json:"id"`
-    GID           string         `json:"gid"`
-    Source        string         `json:"source"`
-    TargetPath    string         `json:"targetPath"`
-    // Name is a read-only field populated by the downloader via events.
-    Name          string         `json:"name,omitempty"`
-    // Files is an optional, read-only list of files for this download.
-    // It is populated by downloader adapters when available.
-    Files         []DownloadFile `json:"files,omitempty"`
-    Status        DownloadStatus `json:"status"`
-    DesiredStatus DownloadStatus `json:"desiredStatus,omitempty"`
-    CreatedAt     time.Time      `json:"createdAt"`
+	ID         string `json:"id"`
+	GID        string `json:"gid"`
+	Source     string `json:"source"`
+	TargetPath string `json:"targetPath"`
+	// Name is a read-only field populated by the downloader via events.
+	Name string `json:"name,omitempty"`
+	// Files is an optional, read-only list of files for this download.
+	// It is populated by downloader adapters when available.
+	Files         []DownloadFile `json:"files,omitempty"`
+	Status        DownloadStatus `json:"status"`
+	DesiredStatus DownloadStatus `json:"desiredStatus,omitempty"`
+	CreatedAt     time.Time      `json:"createdAt"`
 }
 
 // DownloadFile represents a single file within a multi-file download.
 // All fields are optional, depending on downloader capabilities.
 type DownloadFile struct {
-    // Path is a relative path or filename for the file within the download.
-    Path      string `json:"path"`
-    // Length is the size of the file in bytes, if known.
-    Length    int64  `json:"length,omitempty"`
-    // Completed is the number of bytes downloaded for this file, if known.
-    Completed int64  `json:"completed,omitempty"`
+	// Path is a relative path or filename for the file within the download.
+	Path string `json:"path"`
+	// Length is the size of the file in bytes, if known.
+	Length int64 `json:"length,omitempty"`
+	// Completed is the number of bytes downloaded for this file, if known.
+	Completed int64 `json:"completed,omitempty"`
 }
 
 // Possible DownloadStatus values.
 const (
-    StatusQueued    DownloadStatus = "Queued"
-    StatusActive    DownloadStatus = "Active"
-    StatusResume    DownloadStatus = "Resume"
-    StatusPaused    DownloadStatus = "Paused"
-    StatusComplete  DownloadStatus = "Complete"
-    StatusCancelled DownloadStatus = "Cancelled"
-    StatusError     DownloadStatus = "Failed"
+	StatusQueued    DownloadStatus = "Queued"
+	StatusActive    DownloadStatus = "Active"
+	StatusResume    DownloadStatus = "Resume"
+	StatusPaused    DownloadStatus = "Paused"
+	StatusComplete  DownloadStatus = "Complete"
+	StatusCancelled DownloadStatus = "Cancelled"
+	StatusError     DownloadStatus = "Failed"
 )
 
 // Downloads is a slice of Download pointers.
@@ -62,8 +61,8 @@ var (
 	ErrInvalidSource = errors.New("invalid source")
 	// ErrTargetPath signals that the provided target path is invalid.
 	ErrTargetPath = errors.New("invalid target path")
-    // ErrConflict signals a file collision based on collision policy.
-    ErrConflict = errors.New("file conflict")
+	// ErrConflict signals a file collision based on collision policy.
+	ErrConflict = errors.New("file conflict")
 )
 
 // ToJSON writes the slice of downloads as JSON to the writer.
@@ -77,16 +76,16 @@ func (d *Download) FromJSON(r io.Reader) error { return json.NewDecoder(r).Decod
 
 // Clone returns a copy of the download. The receiver is left unchanged.
 func (d *Download) Clone() *Download {
-    if d == nil {
-        return nil
-    }
-    cp := *d
-    // Deep copy Files slice to avoid data races through shared backing arrays.
-    if len(d.Files) > 0 {
-        cp.Files = make([]DownloadFile, len(d.Files))
-        copy(cp.Files, d.Files)
-    }
-    return &cp
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	// Deep copy Files slice to avoid data races through shared backing arrays.
+	if len(d.Files) > 0 {
+		cp.Files = make([]DownloadFile, len(d.Files))
+		copy(cp.Files, d.Files)
+	}
+	return &cp
 }
 
 // Clone returns copies of each download in the slice.
@@ -100,5 +99,6 @@ func (ds Downloads) Clone() Downloads {
 	return out
 }
 
-// ParseID converts an ID string to an integer.
-func ParseID(s string) (int, error) { return strconv.Atoi(s) }
+// ParseID is deprecated and retained for backward compatibility.
+// It simply returns the provided string.
+func ParseID(s string) (string, error) { return s, nil }

--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -29,7 +29,7 @@ type Adapter struct {
 	rep downloader.Reporter
 
 	mu         sync.RWMutex
-	gidToID    map[string]int
+	gidToID    map[string]string
 	activeGIDs map[string]struct{}
 	lastProg   map[string]downloader.Progress
 	pollMS     int
@@ -44,7 +44,7 @@ func NewAdapter(cl *aria2.Client, rep downloader.Reporter) *Adapter {
 			poll = n
 		}
 	}
-	return &Adapter{cl: cl, rep: rep, gidToID: make(map[string]int), activeGIDs: make(map[string]struct{}), lastProg: make(map[string]downloader.Progress), pollMS: poll, log: slog.Default()}
+	return &Adapter{cl: cl, rep: rep, gidToID: make(map[string]string), activeGIDs: make(map[string]struct{}), lastProg: make(map[string]downloader.Progress), pollMS: poll, log: slog.Default()}
 }
 
 var _ downloader.Downloader = (*Adapter)(nil)
@@ -351,14 +351,14 @@ func (a *Adapter) Purge(ctx context.Context, dl *data.Download) error {
 
 // EmitComplete can be used by callers to signal that a download finished
 // successfully. Typically this would be triggered by an aria2 notification.
-func (a *Adapter) emitComplete(id int, gid string) {
+func (a *Adapter) emitComplete(id string, gid string) {
 	if a.rep != nil {
 		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventComplete})
 	}
 }
 
 // EmitFailed signals that a download has failed.
-func (a *Adapter) emitFailed(id int, gid string) {
+func (a *Adapter) emitFailed(id string, gid string) {
 	if a.rep != nil {
 		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventFailed})
 	}
@@ -366,7 +366,7 @@ func (a *Adapter) emitFailed(id int, gid string) {
 
 // EmitProgress publishes a progress update for the given download. Callers are
 // responsible for providing whatever metrics they have available.
-func (a *Adapter) emitProgress(id int, gid string, p downloader.Progress) {
+func (a *Adapter) emitProgress(id string, gid string, p downloader.Progress) {
 	if a.rep != nil {
 		a.rep.Report(downloader.Event{ID: id, GID: gid, Type: downloader.EventProgress, Progress: &p})
 	}

--- a/internal/downloader/aria2/adapter_test.go
+++ b/internal/downloader/aria2/adapter_test.go
@@ -50,7 +50,7 @@ func newTestAdapterWithEvents(t *testing.T, secret string, rt http.RoundTripper)
 
 func TestAdapterStart(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		dl := &data.Download{ID: 1, Source: "http://example.com/files/movie.mkv", TargetPath: "/tmp"}
+		dl := &data.Download{ID: "1", Source: "http://example.com/files/movie.mkv", TargetPath: "/tmp"}
 		call := 0
 		rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			call++
@@ -153,7 +153,7 @@ func must[T any](v T, err error) T {
 }
 
 func TestAdapterResumeEmitsMeta(t *testing.T) {
-	dl := &data.Download{ID: 1, Source: "magnet:?xt=urn:btih:abc&dn=Cool.Name.2024", GID: "gid-9"}
+	dl := &data.Download{ID: "1", Source: "magnet:?xt=urn:btih:abc&dn=Cool.Name.2024", GID: "gid-9"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -213,7 +213,7 @@ func TestAdapterPurgeDeletesFiles(t *testing.T) {
 	if err := os.WriteFile(file+".aria2", []byte("x"), 0o644); err != nil {
 		t.Fatalf("write control: %v", err)
 	}
-	dl := &data.Download{ID: 1, GID: "gid1", TargetPath: tmpDir}
+	dl := &data.Download{ID: "1", GID: "gid1", TargetPath: tmpDir}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -258,7 +258,7 @@ func TestAdapterPurgeDeletesFiles(t *testing.T) {
 }
 
 func TestAdapterEmitsFilesMeta(t *testing.T) {
-	dl := &data.Download{ID: 42, Source: "http://example.com/pack", TargetPath: "/tmp"}
+	dl := &data.Download{ID: "42", Source: "http://example.com/pack", TargetPath: "/tmp"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -331,7 +331,7 @@ func TestAdapterEmitsFilesMeta(t *testing.T) {
 }
 
 func TestAdapterFiltersDotFiles(t *testing.T) {
-	dl := &data.Download{ID: 7, Source: "http://example.com/onefile", TargetPath: "/tmp"}
+	dl := &data.Download{ID: "7", Source: "http://example.com/onefile", TargetPath: "/tmp"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -399,7 +399,7 @@ func TestAdapterFiltersDotFiles(t *testing.T) {
 }
 
 func TestAdapterStartMagnetFollowedBySwap(t *testing.T) {
-	dl := &data.Download{ID: 11, Source: "magnet:?xt=urn:btih:abc&dn=My.Torrent", TargetPath: "/tmp"}
+	dl := &data.Download{ID: "11", Source: "magnet:?xt=urn:btih:abc&dn=My.Torrent", TargetPath: "/tmp"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -456,7 +456,7 @@ func TestAdapterStartMagnetFollowedBySwap(t *testing.T) {
 }
 
 func TestAdapterResumeFollowedBySwap(t *testing.T) {
-	dl := &data.Download{ID: 21, Source: "magnet:?xt=urn:btih:abc&dn=Z.Name", GID: "metaG"}
+	dl := &data.Download{ID: "21", Source: "magnet:?xt=urn:btih:abc&dn=Z.Name", GID: "metaG"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++
@@ -594,7 +594,7 @@ func TestAdapterPauseCancel(t *testing.T) {
 }
 
 func TestAdapterStartConflictMapsErrConflict(t *testing.T) {
-	dl := &data.Download{ID: 71, Source: "http://example.com/file.bin", TargetPath: "/tmp"}
+	dl := &data.Download{ID: "71", Source: "http://example.com/file.bin", TargetPath: "/tmp"}
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// addUri returns an RPC error that simulates a file-exists failure
 		rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Error: &rpcError{Code: 1, Message: "File already exists"}})
@@ -611,7 +611,7 @@ func TestAdapterStartConflictMapsErrConflict(t *testing.T) {
 }
 
 func TestAdapterResumeConflictMapsErrConflict(t *testing.T) {
-	dl := &data.Download{ID: 72, GID: "gid-72"}
+	dl := &data.Download{ID: "72", GID: "gid-72"}
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		// unpause returns conflict
 		rb, _ := json.Marshal(rpcResp{Jsonrpc: "2.0", ID: "torrus", Error: &rpcError{Code: 1, Message: "File exists"}})
@@ -623,7 +623,6 @@ func TestAdapterResumeConflictMapsErrConflict(t *testing.T) {
 		t.Fatalf("expected ErrConflict, got %v", err)
 	}
 }
-
 
 func TestAdapterCancelNotFoundMapsErrNotFound(t *testing.T) {
 	dl := &data.Download{GID: "gid-missing"}
@@ -641,12 +640,12 @@ func TestAdapterCancelNotFoundMapsErrNotFound(t *testing.T) {
 func TestAdapterHandleNotification(t *testing.T) {
 	events := make(chan downloader.Event, 2)
 	rep := downloader.NewChanReporter(events)
-	a := &Adapter{rep: rep, gidToID: map[string]int{"g1": 1, "g2": 2}, activeGIDs: map[string]struct{}{}, lastProg: map[string]downloader.Progress{}}
+	a := &Adapter{rep: rep, gidToID: map[string]string{"g1": "1", "g2": "2"}, activeGIDs: map[string]struct{}{}, lastProg: map[string]downloader.Progress{}}
 
 	// Complete event
 	a.handleNotification(context.Background(), aria2.Notification{Method: "aria2.onDownloadComplete", Params: []aria2.NotificationEvent{{GID: "g1"}}})
 	ev := <-events
-	if ev.Type != downloader.EventComplete || ev.ID != 1 || ev.GID != "g1" {
+	if ev.Type != downloader.EventComplete || ev.ID != "1" || ev.GID != "g1" {
 		t.Fatalf("unexpected event %#v", ev)
 	}
 	if _, ok := a.gidToID["g1"]; ok {
@@ -656,7 +655,7 @@ func TestAdapterHandleNotification(t *testing.T) {
 	// Error event
 	a.handleNotification(context.Background(), aria2.Notification{Method: "aria2.onDownloadError", Params: []aria2.NotificationEvent{{GID: "g2"}}})
 	ev = <-events
-	if ev.Type != downloader.EventFailed || ev.ID != 2 || ev.GID != "g2" {
+	if ev.Type != downloader.EventFailed || ev.ID != "2" || ev.GID != "g2" {
 		t.Fatalf("unexpected event %#v", ev)
 	}
 }
@@ -664,7 +663,7 @@ func TestAdapterHandleNotification(t *testing.T) {
 func TestAdapterMetadataCompleteTriggersFollowedBySwap(t *testing.T) {
 	// Start with a magnet where immediate followedBy is empty; later a completion
 	// notification for the metadata gid should cause a swap to the real gid.
-	dl := &data.Download{ID: 33, Source: "magnet:?xt=urn:btih:xyz&dn=Title", TargetPath: "/tmp"}
+	dl := &data.Download{ID: "33", Source: "magnet:?xt=urn:btih:xyz&dn=Title", TargetPath: "/tmp"}
 	call := 0
 	rt := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		call++

--- a/internal/downloader/event.go
+++ b/internal/downloader/event.go
@@ -12,7 +12,7 @@ import (
 // events carry transient information about the download and do not
 // mutate repository state yet.
 type Event struct {
-	ID       int
+	ID       string
 	GID      string
 	Type     EventType
 	Progress *Progress

--- a/internal/downloader/noop.go
+++ b/internal/downloader/noop.go
@@ -3,7 +3,6 @@ package downloader
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/tinoosan/torrus/internal/data"
 )
@@ -20,7 +19,7 @@ func NewNoopDownloader() Downloader {
 // Start logs the start request and returns the download ID as a fake GID.
 func (d *noopDownloader) Start(ctx context.Context, dl *data.Download) (string, error) {
 	fmt.Println("noop: start", dl.ID)
-	return strconv.FormatInt(int64(dl.ID), 10), nil
+	return dl.ID, nil
 }
 
 // Pause logs the pause request and does nothing else.

--- a/internal/repo/downloads.go
+++ b/internal/repo/downloads.go
@@ -15,7 +15,7 @@ type DownloadRepo interface {
 // DownloadReader defines read-only access to downloads.
 type DownloadReader interface {
 	List(ctx context.Context) (data.Downloads, error)
-	Get(ctx context.Context, id int) (*data.Download, error)
+	Get(ctx context.Context, id string) (*data.Download, error)
 }
 
 // UpdateFields specifies optional updates. Nil fields mean no change.
@@ -29,14 +29,14 @@ type UpdateFields struct {
 // DownloadWriter defines write operations for downloads.
 type DownloadWriter interface {
 	Add(ctx context.Context, download *data.Download) (*data.Download, error)
-	Update(ctx context.Context, id int, mutate func(*data.Download) error) (*data.Download, error)
+	Update(ctx context.Context, id string, mutate func(*data.Download) error) (*data.Download, error)
 	// AddWithFingerprint performs an atomic check-then-insert based on the
 	// provided fingerprint. If an existing row with the fingerprint exists,
 	// it returns that row and created=false. Otherwise it inserts the provided
 	// download, assigns an ID, and returns created=true.
 	AddWithFingerprint(ctx context.Context, download *data.Download, fingerprint string) (*data.Download, bool, error)
 	// Delete removes the download with the given ID.
-	Delete(ctx context.Context, id int) error
+	Delete(ctx context.Context, id string) error
 }
 
 // DownloadFinder extends lookup helpers

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -32,7 +32,7 @@ func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 	// GETs
 	get := api.Methods("GET").Subrouter()
 	get.HandleFunc("/downloads", downloadHandler.GetDownloads)
-	get.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.GetDownload)
+	get.HandleFunc("/downloads/{id}", downloadHandler.GetDownload)
 
 	// POSTs
 	post := api.Methods("POST").Subrouter()
@@ -41,12 +41,12 @@ func New(logger *slog.Logger, downloadSvc service.Download) *mux.Router {
 
 	// PATCHes
 	patch := api.Methods("PATCH").Subrouter()
-	patch.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.UpdateDownload)
+	patch.HandleFunc("/downloads/{id}", downloadHandler.UpdateDownload)
 	patch.Use(v1.MiddlewarePatchDesired)
 
 	// DELETEs
 	del := api.Methods("DELETE").Subrouter()
-	del.HandleFunc("/downloads/{id:[0-9]+}", downloadHandler.DeleteDownload)
+	del.HandleFunc("/downloads/{id}", downloadHandler.DeleteDownload)
 
 	return r
 }


### PR DESCRIPTION
## Summary
- replace integer download IDs with UUID strings throughout the API and internals
- back in-memory repository with a map for O(1) lookups and UUID generation
- adjust router and OpenAPI to accept UUID ids

## Testing
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b544fdd62c8329ba9adbcace6fa861