### PR TITLE
fix(delete): allow empty TargetPath and correct directory pruning

### DIFF
--- a/internal/downloader/aria2/adapter.go
+++ b/internal/downloader/aria2/adapter.go
@@ -362,6 +362,9 @@ func (a *Adapter) Delete(ctx context.Context, dl *data.Download, deleteFiles boo
 	}
 
 	base := filepath.Clean(dl.TargetPath)
+	if dl.TargetPath == "" {
+		base = ""
+	}
 
 	// Helper to ensure a path is within the base directory.
 	baseWithSep := base
@@ -396,7 +399,7 @@ func (a *Adapter) Delete(ctx context.Context, dl *data.Download, deleteFiles boo
 
 		d := filepath.Dir(p)
 		for {
-			if d == base {
+			if d == base || d == string(os.PathSeparator) || d == "." {
 				break
 			}
 			dirs[d] = struct{}{}
@@ -487,17 +490,17 @@ func (a *Adapter) Delete(ctx context.Context, dl *data.Download, deleteFiles boo
 			return fmt.Errorf("delete %s: %w", d, err)
 		}
 
-		if fi, err := os.Lstat(p); err == nil {
+		if fi, err := os.Lstat(d); err == nil {
 			if fi.IsDir() && fi.Mode()&os.ModeSymlink == 0 {
-				_ = os.RemoveAll(p)
+				_ = os.RemoveAll(d)
 			} else {
-				_ = os.Remove(p)
+				_ = os.Remove(d)
 			}
 		} else {
-			_ = os.Remove(p)
+			_ = os.Remove(d)
 		}
 
-		_ = os.Remove(p + ".aria2")
+		_ = os.Remove(d + ".aria2")
 
 	}
 


### PR DESCRIPTION
## Summary
- treat empty TargetPath as unrestricted before safety checks
- remove undefined variable usage in directory pruning

## Testing
- `go test ./internal/downloader/aria2 -run Delete -count=1` *(fails: a.Purge undefined)*
- `go test ./... -count=1` *(fails: a.Purge undefined in adapter_test.go)*


------
https://chatgpt.com/codex/tasks/task_e_68b567bd830c83299ddf0d6b0b39a0fe