### PR TITLE
ci: build/push dev image to GHCR

### DIFF
--- a/.github/workflows/dev-build.yaml
+++ b/.github/workflows/dev-build.yaml
@@ -1,0 +1,27 @@
+name: Build and Push Dev Image
+
+on:
+  push:
+    branches:
+      - dev   # only build when dev branch is updated
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/tinoosan/torrus:dev


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and push a dev-tagged image to GHCR on pushes to the dev branch.