### PR TITLE
chore(Dockerfile): install bash in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV CGO_ENABLED=0 GOOS=linux GOTOOLCHAIN=auto
 # System deps
 RUN apk add --no-cache ca-certificates
 
+RUN apk add --no-cache bash
+
 # Cache module downloads
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
Adds bash to the Alpine image so scripts and tooling that rely on bash work reliably during build and runtime.\n\nWhy:\n- Some project scripts and third‑party tools expect /bin/bash.\n- Alpine defaults to /bin/ash, causing subtle failures in CI and local runs.\n\nImpact:\n- Minimal footprint change (single package).\n- No behavior change for users who don’t rely on bash.\n\nTest Plan:\n- Build Docker image succeeds locally and in CI.\n- Smoke run of any bash‑based scripts in CI.\n\nNotes:\n- Keeps the base Alpine image, only adds bash.