### PR TITLE
chore(Dockerfile): add alpine stage for system deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /src
 # Faster, reproducible builds
 ENV CGO_ENABLED=0 GOOS=linux GOTOOLCHAIN=auto
 
+FROM alpine:3.20
+
 # System deps
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Adds an explicit alpine:3.20 stage for installing system dependencies before the distroless final image.