### PR TITLE
docs: CHANGELOG 0.1.0 MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.1.0 – 2025-09-20
+
+- Storage: Add PostgreSQL-backed repository (opt-in via `TORRUS_STORAGE=postgres`).
+  - DSN from env (`POSTGRES_HOST`, `POSTGRES_PORT`, `APP_DB`, `APP_USER`, `APP_PASSWORD`, `POSTGRES_SSLMODE`).
+  - Auto-creates `downloads` table with UNIQUE `fingerprint` for MVP.
+  - Graceful shutdown: close DB on server exit.
+  - Update is transactional with `SELECT FOR UPDATE` to prevent lost updates.
+  - Preserve `createdAt` (immutable) on updates.
+- Downloader: Split aria2 adapter into focused files (rpc, ops, files, delete, events) with no behavior change.
+- API: DRY strict JSON decode in v1 middlewares (content-type, size limit, unknown fields).
+- Observability: Retain Prometheus metrics and structured logging; add minor adapter gauges/counters.
+- Docs: Add Postgres/K8s configuration snippet to README.
+
+Notes
+- Default storage remains in-memory unless `TORRUS_STORAGE=postgres` is set.
+- Future work (tracked as issues): CORS allowlist, rate limiting, Postgres integration tests, migrations tooling, downloader shutdown wiring, CI staticcheck & Go matrix, Makefile, and adapter module docs.


### PR DESCRIPTION
Add CHANGELOG.md for 0.1.0 (MVP).

Highlights:
- Postgres repo (opt-in), transactional Update, immutable createdAt, close on shutdown
- aria2 adapter split
- API JSON decode helper
- README Postgres config
