### PR TITLE
ci: build/push image on tags

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,0 +1,40 @@
+name: Release Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/tinoosan/torrus:${{ github.ref_name }}
+            ghcr.io/tinoosan/torrus:latest


### PR DESCRIPTION
Adds a release workflow that builds and pushes to GHCR when a tag like v0.1.0 is pushed. Images are tagged with the version tag and latest.