### PR TITLE
docs: link to K8s deploy guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ docker run -p 9090:9090 \
 ```
 
 ### Kubernetes (prod image)
-See docs for more: docs/running.md and docs/operations.md. A minimal env block:
+See docs for more: docs/running.md, docs/operations.md, and docs/deploy-k8s.md. A minimal env block:
 ```
 env:
 - name: TORRUS_STORAGE

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ contributors can quickly become productive.
 - [Idempotency](idempotency.md)
 - [Configuration](configuration.md)
 - [Running Locally](running-locally.md)
+- [Deploy on Kubernetes](deploy-k8s.md)
 - [CI/CD](ci-cd.md)
 - [Extending Torrus](extending.md)
 - [Packages](packages.md)


### PR DESCRIPTION
Add links to docs/deploy-k8s.md from README and docs/README.md. No Helm content added yet.