### PR TITLE
feat: require POSTGRES_DB_URL for Postgres storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 0.1.0 – 2025-09-20
 
 - Storage: Add PostgreSQL-backed repository (opt-in via `TORRUS_STORAGE=postgres`).
-  - DSN from env (`POSTGRES_HOST`, `POSTGRES_PORT`, `APP_DB`, `APP_USER`, `APP_PASSWORD`, `POSTGRES_SSLMODE`).
+  - DSN from env via `POSTGRES_DB_URL` (e.g., `postgres://user:pass@host:5432/db?sslmode=disable`).
   - Auto-creates `downloads` table with UNIQUE `fingerprint` for MVP.
   - Graceful shutdown: close DB on server exit.
   - Update is transactional with `SELECT FOR UPDATE` to prevent lost updates.

--- a/README.md
+++ b/README.md
@@ -100,15 +100,9 @@ Common environment variables:
 
 Enable Postgres-backed storage with:
 - `TORRUS_STORAGE=postgres`
-- Connection envs (defaults in parentheses):
-  - `POSTGRES_HOST` (postgres)
-  - `POSTGRES_PORT` (5432)
-  - `APP_DB` (torrus)
-  - `APP_USER` (torrus)
-  - `APP_PASSWORD` (no default; from Secret)
-  - `POSTGRES_SSLMODE` (disable)
+- `POSTGRES_DB_URL` (full DSN), e.g. `postgres://torrus:enc%25oded@postgres:5432/torrus?sslmode=disable`
 
-Example Secret:
+Example Secret (preferred single DSN):
 
 ```
 apiVersion: v1
@@ -117,10 +111,7 @@ metadata:
   name: postgres-auth
 type: Opaque
 stringData:
-  POSTGRES_PASSWORD: "changeMeAdmin"
-  APP_DB: "torrus"
-  APP_USER: "torrus"
-  APP_PASSWORD: "changeMeApp"
+  DATABASE_URL: "postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable"
 ```
 
 Deployment envs:
@@ -128,25 +119,11 @@ Deployment envs:
 ```
 - name: TORRUS_STORAGE
   value: postgres
-- name: POSTGRES_HOST
-  value: postgres
-- name: POSTGRES_PORT
-  value: "5432"
-- name: APP_DB
+- name: POSTGRES_DB_URL
   valueFrom:
     secretKeyRef:
       name: postgres-auth
-      key: APP_DB
-- name: APP_USER
-  valueFrom:
-    secretKeyRef:
-      name: postgres-auth
-      key: APP_USER
-- name: APP_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: postgres-auth
-      key: APP_PASSWORD
+      key: DATABASE_URL
 ```
 
 Notes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,12 +25,7 @@ Environment variables, defaults and a sample `.env`.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `TORRUS_STORAGE` | empty | Set to `postgres` to enable Postgres-backed repo (otherwise in-memory). |
-| `POSTGRES_HOST` | `postgres` | Postgres host/service name. |
-| `POSTGRES_PORT` | `5432` | Postgres port. |
-| `APP_DB` | `torrus` | Database name for the app. |
-| `APP_USER` | `torrus` | Database user. |
-| `APP_PASSWORD` | empty | Database password (use a Secret). |
-| `POSTGRES_SSLMODE` | `disable` | SSL mode (e.g., `require` in managed DBs). |
+| `POSTGRES_DB_URL` | empty | Full Postgres DSN, e.g. `postgres://user:pass@host:5432/db?sslmode=disable`. |
 
 ### Example `.env`
 ```
@@ -50,12 +45,7 @@ LOG_MAX_AGE_DAYS=7
 
 # Storage (opt-in Postgres)
 TORRUS_STORAGE=postgres
-POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
-APP_DB=torrus
-APP_USER=torrus
-APP_PASSWORD=changeMeApp
-POSTGRES_SSLMODE=disable
+POSTGRES_DB_URL=postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable
 ```
 
 See [running locally](running-locally.md) for using this file with

--- a/docs/deploy-k8s.md
+++ b/docs/deploy-k8s.md
@@ -11,7 +11,7 @@ Secrets. Adjust namespaces and resource values for your cluster.
 
 ## Secrets
 
-Postgres credentials (you provided this layout):
+Postgres credentials (single DSN recommended):
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -19,10 +19,7 @@ metadata:
   name: postgres-auth
 type: Opaque
 stringData:
-  POSTGRES_PASSWORD: "changeMeAdmin"
-  APP_DB: "torrus"
-  APP_USER: "torrus"
-  APP_PASSWORD: "changeMeApp"
+  DATABASE_URL: "postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable"
 ```
 
 API token Secret:
@@ -82,19 +79,9 @@ spec:
           value: aria2
         - name: ARIA2_RPC_URL
           value: http://aria2:6800/jsonrpc
-        # Postgres wiring
-        - name: POSTGRES_HOST
-          value: postgres
-        - name: POSTGRES_PORT
-          value: "5432"
-        - name: APP_DB
-          valueFrom: { secretKeyRef: { name: postgres-auth, key: APP_DB } }
-        - name: APP_USER
-          valueFrom: { secretKeyRef: { name: postgres-auth, key: APP_USER } }
-        - name: APP_PASSWORD
-          valueFrom: { secretKeyRef: { name: postgres-auth, key: APP_PASSWORD } }
-        - name: POSTGRES_SSLMODE
-          value: disable
+        # Postgres wiring (single DSN)
+        - name: POSTGRES_DB_URL
+          valueFrom: { secretKeyRef: { name: postgres-auth, key: DATABASE_URL } }
         resources:
           requests: { cpu: 100m, memory: 128Mi }
           limits:   { cpu: 500m, memory: 512Mi }
@@ -149,5 +136,5 @@ spec:
 ## Notes
 - The API uses a distroless image for releases; there is no shell. Use logs and health endpoints for troubleshooting.
 - Set `TORRUS_API_TOKEN` in all environments. Health/readiness/metrics remain unauthenticated by design.
-- For production, consider managed Postgres and set `POSTGRES_SSLMODE=require`.
+- For production, consider managed Postgres and include `sslmode=require` in `POSTGRES_DB_URL`.
 - Future versions will use versioned DB migrations instead of auto-creating the schema.

--- a/internal/repo/postgres.go
+++ b/internal/repo/postgres.go
@@ -44,26 +44,21 @@ func NewPostgresRepo(dsn string) (*PostgresRepo, error) {
     return r, nil
 }
 
-// NewPostgresRepoFromEnv constructs a DSN using common env vars.
-// Recognizes: POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD.
-// Defaults: host=postgres, port=5432, db=torrus, user=torrus, password="".
+// NewPostgresRepoFromEnv reads DSN from env.
+// Required: POSTGRES_DB_URL (complete DSN, e.g. postgres://user:pass@host:5432/db?sslmode=disable)
+// If POSTGRES_DB_URL is unset or empty, an error is returned.
 func NewPostgresRepoFromEnv() (*PostgresRepo, error) {
-    host := getenv("POSTGRES_HOST", "postgres")
-    port := getenv("POSTGRES_PORT", "5432")
-    db := getenv("POSTGRES_DB", "torrus")
-    user := getenv("POSTGRES_USER", "torrus")
-    pass := getenv("POSTGRES_PASSWORD", "")
-    ssl := getenv("POSTGRES_SSLMODE", "disable")
-    dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", urlEscape(user), urlEscape(pass), host, port, db, ssl)
+    dsn := os.Getenv("POSTGRES_DB_URL")
+    if strings.TrimSpace(dsn) == "" {
+        return nil, fmt.Errorf("POSTGRES_DB_URL is required when TORRUS_STORAGE=postgres")
+    }
     return NewPostgresRepo(dsn)
 }
 
 func getenv(k, def string) string { if v := os.Getenv(k); v != "" { return v }; return def }
 
-func urlEscape(s string) string {
-    // Minimal escape for DSN components; for simplicity rely on fmt construction with no special chars typically
-    return s
-}
+// urlEscape is obsolete; retained for backward compatibility of imports.
+func urlEscape(s string) string { return s }
 
 func (r *PostgresRepo) Close() error { return r.db.Close() }
 


### PR DESCRIPTION
Require POSTGRES_DB_URL for DB connection; remove legacy env var fallback. Update README and docs. This avoids URL encoding pitfalls for special characters in credentials.