### PR TITLE
chore: remove unused Postgres helper functions

### DIFF
--- a/internal/repo/postgres.go
+++ b/internal/repo/postgres.go
@@ -55,10 +55,7 @@ func NewPostgresRepoFromEnv() (*PostgresRepo, error) {
     return NewPostgresRepo(dsn)
 }
 
-func getenv(k, def string) string { if v := os.Getenv(k); v != "" { return v }; return def }
-
-// urlEscape is obsolete; retained for backward compatibility of imports.
-func urlEscape(s string) string { return s }
+// (intentionally left blank) removed unused helpers.
 
 func (r *PostgresRepo) Close() error { return r.db.Close() }
 


### PR DESCRIPTION
Remove two unused functions (getenv, urlEscape) flagged by golangci-lint in internal/repo/postgres.go. Build verified with 'go build ./...'.