### PR TITLE
feat: build Postgres DSN from env vars with proper encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 0.1.0 – 2025-09-20
 
 - Storage: Add PostgreSQL-backed repository (opt-in via `TORRUS_STORAGE=postgres`).
-  - DSN from env via `POSTGRES_DB_URL` (e.g., `postgres://user:pass@host:5432/db?sslmode=disable`).
+  - DSN built from env (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_SSLMODE`), with proper URL-encoding of credentials.
   - Auto-creates `downloads` table with UNIQUE `fingerprint` for MVP.
   - Graceful shutdown: close DB on server exit.
   - Update is transactional with `SELECT FOR UPDATE` to prevent lost updates.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,15 @@ Common environment variables:
 
 Enable Postgres-backed storage with:
 - `TORRUS_STORAGE=postgres`
-- `POSTGRES_DB_URL` (full DSN), e.g. `postgres://torrus:enc%25oded@postgres:5432/torrus?sslmode=disable`
+- Connection envs (defaults in parentheses):
+  - `POSTGRES_HOST` (postgres)
+  - `POSTGRES_PORT` (5432)
+  - `POSTGRES_DB` (torrus)
+  - `POSTGRES_USER` (torrus)
+  - `POSTGRES_PASSWORD` (no default; from Secret)
+  - `POSTGRES_SSLMODE` (disable)
 
-Example Secret (preferred single DSN):
+Example Secret:
 
 ```
 apiVersion: v1
@@ -111,7 +117,9 @@ metadata:
   name: postgres-auth
 type: Opaque
 stringData:
-  DATABASE_URL: "postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable"
+  POSTGRES_DB: "torrus"
+  POSTGRES_USER: "torrus"
+  POSTGRES_PASSWORD: "changeMeAppWith%Specials"
 ```
 
 Deployment envs:
@@ -119,11 +127,18 @@ Deployment envs:
 ```
 - name: TORRUS_STORAGE
   value: postgres
-- name: POSTGRES_DB_URL
-  valueFrom:
-    secretKeyRef:
-      name: postgres-auth
-      key: DATABASE_URL
+- name: POSTGRES_HOST
+  value: postgres
+- name: POSTGRES_PORT
+  value: "5432"
+- name: POSTGRES_DB
+  valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_DB } }
+- name: POSTGRES_USER
+  valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_USER } }
+- name: POSTGRES_PASSWORD
+  valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_PASSWORD } }
+- name: POSTGRES_SSLMODE
+  value: disable
 ```
 
 Notes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,12 @@ Environment variables, defaults and a sample `.env`.
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `TORRUS_STORAGE` | empty | Set to `postgres` to enable Postgres-backed repo (otherwise in-memory). |
-| `POSTGRES_DB_URL` | empty | Full Postgres DSN, e.g. `postgres://user:pass@host:5432/db?sslmode=disable`. |
+| `POSTGRES_HOST` | `postgres` | Postgres host/service name. |
+| `POSTGRES_PORT` | `5432` | Postgres port. |
+| `POSTGRES_DB` | `torrus` | Database name for the app. |
+| `POSTGRES_USER` | `torrus` | Database user. |
+| `POSTGRES_PASSWORD` | empty | Database password (use a Secret). |
+| `POSTGRES_SSLMODE` | `disable` | SSL mode (e.g., `require` in managed DBs). |
 
 ### Example `.env`
 ```
@@ -45,7 +50,12 @@ LOG_MAX_AGE_DAYS=7
 
 # Storage (opt-in Postgres)
 TORRUS_STORAGE=postgres
-POSTGRES_DB_URL=postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=torrus
+POSTGRES_USER=torrus
+POSTGRES_PASSWORD=changeMeApp
+POSTGRES_SSLMODE=disable
 ```
 
 See [running locally](running-locally.md) for using this file with

--- a/docs/deploy-k8s.md
+++ b/docs/deploy-k8s.md
@@ -11,7 +11,7 @@ Secrets. Adjust namespaces and resource values for your cluster.
 
 ## Secrets
 
-Postgres credentials (single DSN recommended):
+Postgres credentials:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -19,7 +19,9 @@ metadata:
   name: postgres-auth
 type: Opaque
 stringData:
-  DATABASE_URL: "postgres://torrus:changeMeApp@postgres:5432/torrus?sslmode=disable"
+  POSTGRES_DB: "torrus"
+  POSTGRES_USER: "torrus"
+  POSTGRES_PASSWORD: "changeMeAppWith%Specials"
 ```
 
 API token Secret:
@@ -79,9 +81,19 @@ spec:
           value: aria2
         - name: ARIA2_RPC_URL
           value: http://aria2:6800/jsonrpc
-        # Postgres wiring (single DSN)
-        - name: POSTGRES_DB_URL
-          valueFrom: { secretKeyRef: { name: postgres-auth, key: DATABASE_URL } }
+        # Postgres wiring
+        - name: POSTGRES_HOST
+          value: postgres
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_DB } }
+        - name: POSTGRES_USER
+          valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_USER } }
+        - name: POSTGRES_PASSWORD
+          valueFrom: { secretKeyRef: { name: postgres-auth, key: POSTGRES_PASSWORD } }
+        - name: POSTGRES_SSLMODE
+          value: disable
         resources:
           requests: { cpu: 100m, memory: 128Mi }
           limits:   { cpu: 500m, memory: 512Mi }
@@ -136,5 +148,5 @@ spec:
 ## Notes
 - The API uses a distroless image for releases; there is no shell. Use logs and health endpoints for troubleshooting.
 - Set `TORRUS_API_TOKEN` in all environments. Health/readiness/metrics remain unauthenticated by design.
-- For production, consider managed Postgres and include `sslmode=require` in `POSTGRES_DB_URL`.
+- For production, consider managed Postgres and set `POSTGRES_SSLMODE=require`.
 - Future versions will use versioned DB migrations instead of auto-creating the schema.


### PR DESCRIPTION
Revert to component env vars for Postgres connection and construct DSN via net/url to handle special characters in credentials. Update README and docs to reflect separate envs again.